### PR TITLE
Revert "deafult go releases to prerelease state (#74)"

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -34,10 +34,6 @@ archives:
     dst: "config/debug.yaml"
   - src: "config/prod.yaml"
     dst: "config/prod.yaml"
-
-release:
-  prerelease: true
-
 changelog:
   sort: asc
   filters:


### PR DESCRIPTION
This reverts commit 296e4df134fd444d8ffefe1530ed50b06eef3a77.
