### PR TITLE
Use scheduler to cleanup notifications instead of cascade

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ The configuration files are yaml mappings with the following values:
 | `scheduler_jobs.due_frequency`           | `5m`                                                | The interval for sending regular notifications.                             |
 | `scheduler_jobs.overdue_frequency`       | `24h`                                               | The interval for sending overdue notifications.                             |
 | `scheduler_jobs.password_reset_validity` | `24h`                                               | How long password reset tokens are valid for.                               |
+| `scheduler_jobs.notification_cleanup`       | `10m`                                              | The interval for cleaning up sent notifications.                              |
+| `scheduler_jobs.token_expiration_cleanup`    | `24h`                                             | The interval for cleaning up expired tokens.                                  |
 | `token_expiration_reminder`              | `72h`                                               | How long before an app token expiration to send a reminder for it.          |
 | `email.host`                             | (empty)                                             | The email server host.                                                      |
 | `email.port`                             | (empty)                                             | The email server port.                                                      |

--- a/config/config.dev.yaml
+++ b/config/config.dev.yaml
@@ -20,6 +20,8 @@ scheduler_jobs:
   overdue_frequency: 1m
   password_reset_validity: 1m
   token_expiration_reminder: 1m
+  notification_cleanup: 10s
+  token_expiration_cleanup: 1h
 email:
   host: 
   port: 

--- a/config/config.go
+++ b/config/config.go
@@ -42,6 +42,8 @@ type SchedulerConfig struct {
 	OverdueFrequency        time.Duration `mapstructure:"overdue_frequency" yaml:"overdue_frequency" default:"1d"`
 	PasswordResetValidity   time.Duration `mapstructure:"password_reset_validity" yaml:"password_reset_validity" default:"24h"`
 	TokenExpirationReminder time.Duration `mapstructure:"token_expiration_reminder" yaml:"token_expiration_reminder" default:"72h"`
+	NotificationCleanup     time.Duration `mapstructure:"notification_cleanup" yaml:"notification_cleanup" default:"10m"`
+	TokenExpirationCleanup  time.Duration `mapstructure:"token_expiration_cleanup" yaml:"token_expiration_cleanup" default:"24h"`
 }
 
 type EmailConfig struct {

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -20,6 +20,8 @@ scheduler_jobs:
   overdue_frequency: 24h
   password_reset_validity: 24h
   token_expiration_reminder: 72h
+  notification_cleanup: 10m
+  token_expiration_cleanup: 24h
 email:
   host: 
   port: 

--- a/internal/models/notification.go
+++ b/internal/models/notification.go
@@ -13,8 +13,8 @@ type Notification struct {
 	ScheduledFor time.Time `json:"scheduled_for" gorm:"column:scheduled_for;not null;index"`
 	CreatedAt    time.Time `json:"created_at" gorm:"column:created_at;default:CURRENT_TIMESTAMP"`
 
-	Task Task `json:"-" gorm:"foreignKey:TaskID;constraint:OnDelete:CASCADE;"`
-	User User `json:"-" gorm:"foreignKey:UserID;constraint:OnDelete:CASCADE;"`
+	Task Task `json:"-" gorm:"foreignKey:TaskID"`
+	User User `json:"-" gorm:"foreignKey:UserID"`
 }
 
 type NotificationProviderType string

--- a/internal/services/notifications/notifications.go
+++ b/internal/services/notifications/notifications.go
@@ -40,7 +40,7 @@ func NewNotifier(cfg *config.Config, nr *nRepo.NotificationRepository) *Notifier
 	}
 }
 
-func (n *Notifier) CleanupInvalidNotifications(c context.Context) error {
+func (n *Notifier) cleanupInvalidNotifications(c context.Context) error {
 	log := logging.FromContext(c)
 	log.Debug("Cleaning up notifications for invalid or inactive tasks")
 
@@ -66,7 +66,7 @@ func (n *Notifier) CleanupInvalidNotifications(c context.Context) error {
 	return nil
 }
 
-func (n *Notifier) CleanupSentNotifications(c context.Context) error {
+func (n *Notifier) cleanupSentNotifications(c context.Context) error {
 	log := logging.FromContext(c)
 	log.Debug("Cleaning sent notifications")
 
@@ -74,6 +74,18 @@ func (n *Notifier) CleanupSentNotifications(c context.Context) error {
 	err := n.nRepo.DeleteSentNotifications(c, deleteBefore)
 	if err != nil {
 		return fmt.Errorf("error deleting sent notifications: %s", err.Error())
+	}
+
+	return nil
+}
+
+func (n *Notifier) CleanupNotifications(c context.Context) error {
+	if err := n.cleanupInvalidNotifications(c); err != nil {
+		return fmt.Errorf("error cleaning up invalid notifications: %s", err.Error())
+	}
+
+	if err := n.cleanupSentNotifications(c); err != nil {
+		return fmt.Errorf("error cleaning up sent notifications: %s", err.Error())
 	}
 
 	return nil

--- a/internal/services/scheduler/scheduler.go
+++ b/internal/services/scheduler/scheduler.go
@@ -40,11 +40,10 @@ func (s *Scheduler) Start(c context.Context) {
 
 	go s.runScheduler(c, "NOTIFICATION_SCHEDULER", s.notifier.GenerateOverdueNotifications, s.config.OverdueFrequency)
 	go s.runScheduler(c, "NOTIFICATION_SENDER", s.notifier.LoadAndSendNotificationJob, s.config.DueFrequency)
-	go s.runScheduler(c, "NOTIFICATION_CLEANUP", s.notifier.CleanupSentNotifications, 2*s.config.DueFrequency)
-	go s.runScheduler(c, "NOTIFICATION_INVALID_CLEANUP", s.notifier.CleanupInvalidNotifications, time.Duration(5)*time.Second)
+	go s.runScheduler(c, "NOTIFICATION_CLEANUP", s.notifier.CleanupNotifications, s.config.NotificationCleanup)
 	go s.runScheduler(c, "PASSWORD_RESET_CLEANUP", s.passwordResetCleaner.CleanupStalePasswordResets, s.config.PasswordResetValidity)
 	go s.runScheduler(c, "TOKEN_EXPIRATION_REMINDER", s.appTokenCleaner.SendTokenExpirationReminder, s.config.TokenExpirationReminder)
-	go s.runScheduler(c, "TOKEN_EXPIRATION_CLEANUP", s.appTokenCleaner.CleanupExpiredTokens, time.Duration(24)*time.Hour)
+	go s.runScheduler(c, "TOKEN_EXPIRATION_CLEANUP", s.appTokenCleaner.CleanupExpiredTokens, s.config.TokenExpirationCleanup)
 }
 
 func (s *Scheduler) runScheduler(c context.Context, jobName string, job func(c context.Context) error, interval time.Duration) {

--- a/internal/services/scheduler/scheduler.go
+++ b/internal/services/scheduler/scheduler.go
@@ -41,6 +41,7 @@ func (s *Scheduler) Start(c context.Context) {
 	go s.runScheduler(c, "NOTIFICATION_SCHEDULER", s.notifier.GenerateOverdueNotifications, s.config.OverdueFrequency)
 	go s.runScheduler(c, "NOTIFICATION_SENDER", s.notifier.LoadAndSendNotificationJob, s.config.DueFrequency)
 	go s.runScheduler(c, "NOTIFICATION_CLEANUP", s.notifier.CleanupSentNotifications, 2*s.config.DueFrequency)
+	go s.runScheduler(c, "NOTIFICATION_INVALID_CLEANUP", s.notifier.CleanupInvalidNotifications, time.Duration(5)*time.Second)
 	go s.runScheduler(c, "PASSWORD_RESET_CLEANUP", s.passwordResetCleaner.CleanupStalePasswordResets, s.config.PasswordResetValidity)
 	go s.runScheduler(c, "TOKEN_EXPIRATION_REMINDER", s.appTokenCleaner.SendTokenExpirationReminder, s.config.TokenExpirationReminder)
 	go s.runScheduler(c, "TOKEN_EXPIRATION_CLEANUP", s.appTokenCleaner.CleanupExpiredTokens, time.Duration(24)*time.Hour)


### PR DESCRIPTION
- **add a cleanup task for notifications instead of cascade**
- **merge into existing cleanup job and docs**

cascade logic requires table locking which slows down queries
