### PR TITLE
Fix AssignLabelsToTask transaction usage

### DIFF
--- a/internal/repos/label/label.go
+++ b/internal/repos/label/label.go
@@ -58,11 +58,11 @@ func (r *LabelRepository) AssignLabelsToTask(ctx context.Context, taskID int, us
 	}
 
 	return r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		if err := r.db.WithContext(ctx).Where("task_id = ?", taskID).Delete(&models.TaskLabel{}).Error; err != nil {
+		if err := tx.WithContext(ctx).Where("task_id = ?", taskID).Delete(&models.TaskLabel{}).Error; err != nil {
 			return err
 		}
 
-		if err := r.db.WithContext(ctx).Create(&taskLabels).Error; err != nil {
+		if err := tx.WithContext(ctx).Create(&taskLabels).Error; err != nil {
 			return err
 		}
 


### PR DESCRIPTION
## Summary
- use the passed transaction in AssignLabelsToTask so delete and create run in one transaction

## Testing
- `go test ./...` *(fails: download forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6861c6609338832a998e599d98367653