### PR TITLE
Fix token reminder config entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,9 +98,9 @@ The configuration files are yaml mappings with the following values:
 | `scheduler_jobs.due_frequency`           | `5m`                                                | The interval for sending regular notifications.                             |
 | `scheduler_jobs.overdue_frequency`       | `24h`                                               | The interval for sending overdue notifications.                             |
 | `scheduler_jobs.password_reset_validity` | `24h`                                               | How long password reset tokens are valid for.                               |
-| `scheduler_jobs.notification_cleanup`       | `10m`                                              | The interval for cleaning up sent notifications.                              |
-| `scheduler_jobs.token_expiration_cleanup`    | `24h`                                             | The interval for cleaning up expired tokens.                                  |
-| `token_expiration_reminder`              | `72h`                                               | How long before an app token expiration to send a reminder for it.          |
+| `scheduler_jobs.notification_cleanup`    | `10m`                                               | The interval for cleaning up sent notifications.                            |
+| `scheduler_jobs.token_expiration_cleanup`| `24h`                                               | The interval for cleaning up expired tokens.                                |
+|`scheduler_jobs.token_expiration_reminder`| `72h`                                               | How long before an app token expiration to send a reminder for it.          |
 | `email.host`                             | (empty)                                             | The email server host.                                                      |
 | `email.port`                             | (empty)                                             | The email server port.                                                      |
 | `email.email`                            | (empty)                                             | The email address used for sending emails.                                  |


### PR DESCRIPTION
## Summary
- fix table entry for token expiration reminder

## Testing
- `go test ./...` *(fails: Get "https://storage.googleapis.com/...": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6861c66d1de4832ab62a059b33ee798a