### PR TITLE
Remove temp DB file after tests

### DIFF
--- a/internal/utils/test/database.go
+++ b/internal/utils/test/database.go
@@ -37,4 +37,11 @@ func (suite *DatabaseTestSuite) TearDownTest() {
 		return
 	}
 	db.Close()
+
+	// Remove the temporary database file created for the test
+	if suite.dbFilePath != "" {
+		if err := os.Remove(suite.dbFilePath); err != nil && !os.IsNotExist(err) {
+			log.Printf("failed to remove db file %s: %v", suite.dbFilePath, err)
+		}
+	}
 }

--- a/internal/utils/test/database.go
+++ b/internal/utils/test/database.go
@@ -41,7 +41,7 @@ func (suite *DatabaseTestSuite) TearDownTest() {
 	// Remove the temporary database file created for the test
 	if suite.dbFilePath != "" {
 		if err := os.Remove(suite.dbFilePath); err != nil && !os.IsNotExist(err) {
-			log.Printf("failed to remove db file %s: %v", suite.dbFilePath, err)
+			suite.Require().NoError(err, fmt.Sprintf("failed to remove db file %s", suite.dbFilePath))
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- clean up SQLite test DB file after closing connection

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6861cbf39cac832a8cd5d594ec46d727