### PR TITLE
Implement task uncompletion

### DIFF
--- a/internal/apis/task.go
+++ b/internal/apis/task.go
@@ -1,6 +1,7 @@
 package apis
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -551,9 +552,9 @@ func (h *TasksAPIHandler) uncompleteTask(c *gin.Context) {
 		return
 	}
 
-	go func() {
-		h.nRepo.GenerateNotifications(c, updatedTask)
-	}()
+	go func(task *models.Task) {
+		h.nRepo.GenerateNotifications(context.Background(), task)
+	}(updatedTask)
 
 	c.JSON(http.StatusOK, gin.H{
 		"task": updatedTask,

--- a/internal/repos/task/task.go
+++ b/internal/repos/task/task.go
@@ -91,6 +91,30 @@ func (r *TaskRepository) CompleteTask(c context.Context, task *models.Task, user
 	return err
 }
 
+func (r *TaskRepository) UncompleteTask(c context.Context, taskID int) error {
+	return r.db.WithContext(c).Transaction(func(tx *gorm.DB) error {
+		var last models.TaskHistory
+		if err := tx.Where("task_id = ?", taskID).Order("id desc").First(&last).Error; err != nil {
+			return err
+		}
+
+		if err := tx.Delete(&last).Error; err != nil {
+			return err
+		}
+
+		updates := map[string]interface{}{
+			"next_due_date": last.DueDate,
+			"is_active":     true,
+		}
+
+		if err := tx.Model(&models.Task{}).Where("id = ?", taskID).Updates(updates).Error; err != nil {
+			return err
+		}
+
+		return nil
+	})
+}
+
 func (r *TaskRepository) GetTaskHistory(c context.Context, taskID int) ([]*models.TaskHistory, error) {
 	var histories []*models.TaskHistory
 	if err := r.db.WithContext(c).Where("task_id = ?", taskID).Order("due_date desc").Find(&histories).Error; err != nil {


### PR DESCRIPTION
## Summary
- add TaskRepository.UncompleteTask
- add API handler for undoing task completion
- update task routes
- test uncompleting tasks
- fix error messages for undo route

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6861cd4ebf18832a964d13cdb504e42b