### PR TITLE
Add DB indexes for key fields

### DIFF
--- a/internal/models/label.go
+++ b/internal/models/label.go
@@ -6,7 +6,7 @@ type Label struct {
 	ID        int        `json:"id" gorm:"primary_key"`
 	Name      string     `json:"name" gorm:"column:name;not null"`
 	Color     string     `json:"color" gorm:"type:varchar(7);column:color;not null"`
-	CreatedBy int        `json:"created_by" gorm:"column:created_by;not null"`
+	CreatedBy int        `json:"created_by" gorm:"column:created_by;not null;index"`
 	CreatedAt time.Time  `json:"-" gorm:"column:created_at;default:CURRENT_TIMESTAMP"`
 	UpdatedAt *time.Time `json:"-" gorm:"column:updated_at;default:NULL;autoUpdateTime"`
 

--- a/internal/models/notification.go
+++ b/internal/models/notification.go
@@ -6,8 +6,8 @@ import (
 
 type Notification struct {
 	ID           int       `json:"id" gorm:"primaryKey"`
-	TaskID       int       `json:"task_id" gorm:"column:task_id;not null"`
-	UserID       int       `json:"user_id" gorm:"column:user_id;not null"`
+	TaskID       int       `json:"task_id" gorm:"column:task_id;not null;index"`
+	UserID       int       `json:"user_id" gorm:"column:user_id;not null;index"`
 	Text         string    `json:"text" gorm:"column:text;not null"`
 	IsSent       bool      `json:"is_sent" gorm:"column:is_sent;index;default:false"`
 	ScheduledFor time.Time `json:"scheduled_for" gorm:"column:scheduled_for;not null;index"`

--- a/internal/models/task.go
+++ b/internal/models/task.go
@@ -11,7 +11,7 @@ type Task struct {
 	NextDueDate  *time.Time                 `json:"next_due_date" gorm:"column:next_due_date;index"`
 	EndDate      *time.Time                 `json:"end_date" gorm:"column:end_date;default:NULL"`
 	IsRolling    bool                       `json:"is_rolling" gorm:"column:is_rolling;default:false"`
-	CreatedBy    int                        `json:"-" gorm:"column:created_by;not null"`
+	CreatedBy    int                        `json:"-" gorm:"column:created_by;not null;index"`
 	IsActive     bool                       `json:"-" gorm:"column:is_active;default:true"`
 	Notification NotificationTriggerOptions `json:"notification" gorm:"embedded;embeddedPrefix:notification_"`
 	CreatedAt    time.Time                  `json:"-" gorm:"column:created_at;default:CURRENT_TIMESTAMP"`


### PR DESCRIPTION
## Summary
- index notification TaskID and UserID
- add indexes on CreatedBy for tasks and labels

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686b37dc98dc832abdf1e51949e6a02e