### PR TITLE
Move notification generation and email sending to a background context

### DIFF
--- a/internal/apis/task.go
+++ b/internal/apis/task.go
@@ -212,7 +212,7 @@ func (h *TasksAPIHandler) createTask(c *gin.Context) {
 	}
 
 	go func(task *models.Task, logger *zap.SugaredLogger) {
-		ctx := context.WithValue(context.Background(), "logger", logger)
+		ctx := logging.ContextWithLogger(context.Background(), logger)
 		h.nRepo.GenerateNotifications(ctx, task)
 	}(createdTask, log)
 
@@ -317,7 +317,7 @@ func (h *TasksAPIHandler) editTask(c *gin.Context) {
 	}
 
 	go func(task *models.Task, logger *zap.SugaredLogger) {
-		ctx := context.WithValue(context.Background(), "logger", logger)
+		ctx := logging.ContextWithLogger(context.Background(), logger)
 		h.nRepo.GenerateNotifications(ctx, task)
 	}(updatedTask, log)
 
@@ -405,7 +405,7 @@ func (h *TasksAPIHandler) skipTask(c *gin.Context) {
 	}
 
 	go func(task *models.Task, logger *zap.SugaredLogger) {
-		ctx := context.WithValue(context.Background(), "logger", logger)
+		ctx := logging.ContextWithLogger(context.Background(), logger)
 		h.nRepo.GenerateNotifications(ctx, task)
 	}(updatedTask, log)
 
@@ -532,7 +532,7 @@ func (h *TasksAPIHandler) completeTask(c *gin.Context) {
 	}
 
 	go func(task *models.Task, logger *zap.SugaredLogger) {
-		ctx := context.WithValue(context.Background(), "logger", logger)
+		ctx := logging.ContextWithLogger(context.Background(), logger)
 		h.nRepo.GenerateNotifications(ctx, task)
 	}(updatedTask, log)
 
@@ -592,7 +592,7 @@ func (h *TasksAPIHandler) uncompleteTask(c *gin.Context) {
 	}
 
 	go func(task *models.Task, logger *zap.SugaredLogger) {
-		ctx := context.WithValue(context.Background(), "logger", logger)
+		ctx := logging.ContextWithLogger(context.Background(), logger)
 		h.nRepo.GenerateNotifications(ctx, task)
 	}(updatedTask, log)
 

--- a/internal/apis/task.go
+++ b/internal/apis/task.go
@@ -18,6 +18,7 @@ import (
 	auth "dkhalife.com/tasks/core/internal/utils/auth"
 	jwt "github.com/appleboy/gin-jwt/v2"
 	"github.com/gin-gonic/gin"
+	"go.uber.org/zap"
 	"gorm.io/gorm"
 )
 
@@ -210,9 +211,10 @@ func (h *TasksAPIHandler) createTask(c *gin.Context) {
 		return
 	}
 
-	go func() {
-		h.nRepo.GenerateNotifications(c, createdTask)
-	}()
+	go func(task *models.Task, logger *zap.SugaredLogger) {
+		ctx := context.WithValue(context.Background(), "logger", logger)
+		h.nRepo.GenerateNotifications(ctx, task)
+	}(createdTask, log)
 
 	c.JSON(http.StatusCreated, gin.H{
 		"task": id,
@@ -314,9 +316,10 @@ func (h *TasksAPIHandler) editTask(c *gin.Context) {
 		return
 	}
 
-	go func() {
-		h.nRepo.GenerateNotifications(c, updatedTask)
-	}()
+	go func(task *models.Task, logger *zap.SugaredLogger) {
+		ctx := context.WithValue(context.Background(), "logger", logger)
+		h.nRepo.GenerateNotifications(ctx, task)
+	}(updatedTask, log)
 
 	c.JSON(http.StatusNoContent, gin.H{})
 }
@@ -401,9 +404,10 @@ func (h *TasksAPIHandler) skipTask(c *gin.Context) {
 		return
 	}
 
-	go func() {
-		h.nRepo.GenerateNotifications(c, updatedTask)
-	}()
+	go func(task *models.Task, logger *zap.SugaredLogger) {
+		ctx := context.WithValue(context.Background(), "logger", logger)
+		h.nRepo.GenerateNotifications(ctx, task)
+	}(updatedTask, log)
 
 	c.JSON(http.StatusOK, gin.H{
 		"task": updatedTask,
@@ -527,9 +531,10 @@ func (h *TasksAPIHandler) completeTask(c *gin.Context) {
 		return
 	}
 
-	go func() {
-		h.nRepo.GenerateNotifications(c, updatedTask)
-	}()
+	go func(task *models.Task, logger *zap.SugaredLogger) {
+		ctx := context.WithValue(context.Background(), "logger", logger)
+		h.nRepo.GenerateNotifications(ctx, task)
+	}(updatedTask, log)
 
 	c.JSON(http.StatusOK, gin.H{
 		"task": updatedTask,
@@ -586,9 +591,10 @@ func (h *TasksAPIHandler) uncompleteTask(c *gin.Context) {
 		return
 	}
 
-	go func(task *models.Task) {
-		h.nRepo.GenerateNotifications(context.Background(), task)
-	}(updatedTask)
+	go func(task *models.Task, logger *zap.SugaredLogger) {
+		ctx := context.WithValue(context.Background(), "logger", logger)
+		h.nRepo.GenerateNotifications(ctx, task)
+	}(updatedTask, log)
 
 	c.JSON(http.StatusOK, gin.H{
 		"task": updatedTask,

--- a/internal/apis/user.go
+++ b/internal/apis/user.go
@@ -1,6 +1,7 @@
 package apis
 
 import (
+	"context"
 	"html"
 	"net/http"
 
@@ -16,6 +17,7 @@ import (
 	jwt "github.com/appleboy/gin-jwt/v2"
 	"github.com/gin-gonic/gin"
 	limiter "github.com/ulule/limiter/v3"
+	"go.uber.org/zap"
 )
 
 type UsersAPIHandler struct {
@@ -94,7 +96,10 @@ func (h *UsersAPIHandler) signUp(c *gin.Context) {
 	}
 
 	code := auth.EncodeEmailAndCode(signupReq.Email, token)
-	go h.email.SendWelcomeEmail(c, signupReq.DisplayName, signupReq.Email, code)
+	go func(name, email, code string, logger *zap.SugaredLogger) {
+		ctx := context.WithValue(context.Background(), "logger", logger)
+		h.email.SendWelcomeEmail(ctx, name, email, code)
+	}(signupReq.DisplayName, signupReq.Email, code, log)
 
 	c.JSON(http.StatusCreated, gin.H{})
 }

--- a/internal/apis/user.go
+++ b/internal/apis/user.go
@@ -97,7 +97,7 @@ func (h *UsersAPIHandler) signUp(c *gin.Context) {
 
 	code := auth.EncodeEmailAndCode(signupReq.Email, token)
 	go func(name, email, code string, logger *zap.SugaredLogger) {
-		ctx := context.WithValue(context.Background(), "logger", logger)
+		ctx := logging.ContextWithLogger(context.Background(), logger)
 		h.email.SendWelcomeEmail(ctx, name, email, code)
 	}(signupReq.DisplayName, signupReq.Email, code, log)
 

--- a/internal/services/logging/logging.go
+++ b/internal/services/logging/logging.go
@@ -73,10 +73,9 @@ func DefaultLogger() *zap.SugaredLogger {
 	return defaultLogger
 }
 
-// ContextWithLogger returns a new context with the given logger attached.
 func ContextWithLogger(ctx context.Context, logger *zap.SugaredLogger) context.Context {
 	if ctx == nil {
-		ctx = context.Background()
+		panic("nil context passed to ContextWithLogger")
 	}
 	return context.WithValue(ctx, loggerKey, logger)
 }

--- a/internal/services/logging/logging.go
+++ b/internal/services/logging/logging.go
@@ -9,9 +9,9 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
-type contextKey = string
+type contextKey string
 
-const loggerKey = contextKey("logger")
+const loggerKey contextKey = "logger"
 
 var (
 	defaultLogger     *zap.SugaredLogger
@@ -71,6 +71,14 @@ func DefaultLogger() *zap.SugaredLogger {
 		defaultLogger = NewLogger(conf)
 	})
 	return defaultLogger
+}
+
+// ContextWithLogger returns a new context with the given logger attached.
+func ContextWithLogger(ctx context.Context, logger *zap.SugaredLogger) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return context.WithValue(ctx, loggerKey, logger)
 }
 
 func FromContext(ctx context.Context) *zap.SugaredLogger {


### PR DESCRIPTION
## Summary
- preserve logging context for async notification generation
- ensure welcome email goroutine uses background context

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686b37defc9c832aa49e75dae7ac373e