### PR TITLE
Enable WAL to improve write performance and add db logger

### DIFF
--- a/internal/repos/task/concurrency_test.go
+++ b/internal/repos/task/concurrency_test.go
@@ -1,0 +1,54 @@
+package repos
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"dkhalife.com/tasks/core/internal/models"
+	"dkhalife.com/tasks/core/internal/utils/test"
+	"github.com/stretchr/testify/suite"
+)
+
+type TaskConcurrencyTestSuite struct {
+	test.DatabaseTestSuite
+	repo     *TaskRepository
+	testUser *models.User
+}
+
+func TestTaskConcurrencyTestSuite(t *testing.T) {
+	suite.Run(t, new(TaskConcurrencyTestSuite))
+}
+
+func (s *TaskConcurrencyTestSuite) SetupTest() {
+	s.DatabaseTestSuite.SetupTest()
+	s.repo = &TaskRepository{db: s.DB}
+	s.testUser = &models.User{ID: 1, Email: "concurrent@example.com", Password: "pwd", CreatedAt: time.Now()}
+	s.Require().NoError(s.DB.Create(s.testUser).Error)
+}
+
+func (s *TaskConcurrencyTestSuite) TestConcurrentCreateTask() {
+	ctx := context.Background()
+	dueDate := time.Now().Add(24 * time.Hour)
+
+	wg := sync.WaitGroup{}
+	errCh := make(chan error, 10)
+
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func(title string) {
+			defer wg.Done()
+			task := &models.Task{Title: title, CreatedBy: s.testUser.ID, NextDueDate: &dueDate, IsActive: true, Frequency: models.Frequency{Type: models.RepeatOnce}}
+			_, err := s.repo.CreateTask(ctx, task)
+			errCh <- err
+		}("Task" + string(rune('A'+i)))
+	}
+
+	wg.Wait()
+	close(errCh)
+
+	for err := range errCh {
+		s.NoError(err)
+	}
+}

--- a/internal/utils/database/database.go
+++ b/internal/utils/database/database.go
@@ -1,11 +1,50 @@
 package database
 
 import (
+	"log"
+	"os"
+	"strings"
+	"time"
+
 	"dkhalife.com/tasks/core/config"
 	"github.com/glebarez/sqlite"
 	"gorm.io/gorm"
+	gormLogger "gorm.io/gorm/logger"
 )
 
 func NewDatabase(cfg *config.Config) (*gorm.DB, error) {
-	return gorm.Open(sqlite.Open(cfg.Database.FilePath), &gorm.Config{})
+	level := gormLogger.Warn
+	switch strings.ToLower(cfg.Server.LogLevel) {
+	case "debug", "info":
+		level = gormLogger.Info
+	case "warn", "warning":
+		level = gormLogger.Warn
+	case "error":
+		level = gormLogger.Error
+	case "silent":
+		level = gormLogger.Silent
+	}
+
+	logger := gormLogger.New(
+		log.New(os.Stdout, "\r\n", log.LstdFlags),
+		gormLogger.Config{
+			SlowThreshold: time.Second,
+			LogLevel:      level,
+			Colorful:      false,
+		},
+	)
+
+	db, err := gorm.Open(sqlite.Open(cfg.Database.FilePath), &gorm.Config{Logger: logger})
+	if err != nil {
+		return nil, err
+	}
+
+	if err := db.Exec("PRAGMA journal_mode=WAL;").Error; err != nil {
+		return nil, err
+	}
+	if err := db.Exec("PRAGMA busy_timeout=5000;").Error; err != nil {
+		return nil, err
+	}
+
+	return db, nil
 }

--- a/internal/utils/test/database.go
+++ b/internal/utils/test/database.go
@@ -6,9 +6,10 @@ import (
 	"os"
 	"time"
 
+	"dkhalife.com/tasks/core/config"
+	dbutil "dkhalife.com/tasks/core/internal/utils/database"
 	"dkhalife.com/tasks/core/internal/utils/migration"
 	"github.com/stretchr/testify/suite"
-	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
 )
 
@@ -20,7 +21,8 @@ type DatabaseTestSuite struct {
 
 func (suite *DatabaseTestSuite) SetupTest() {
 	suite.dbFilePath = fmt.Sprintf("%s/testdb_%d.db", os.TempDir(), time.Now().UnixNano())
-	db, err := gorm.Open(sqlite.Open(suite.dbFilePath), &gorm.Config{})
+	cfg := &config.Config{Database: config.DatabaseConfig{FilePath: suite.dbFilePath}}
+	db, err := dbutil.NewDatabase(cfg)
 	suite.Require().NoError(err)
 
 	err = migration.Migration(db)


### PR DESCRIPTION
## Summary
- enable verbose GORM logging
- switch DB initialization to WAL and add busy timeout
- use the same DB setup for tests
- add a concurrency test to ensure updates work under contention
- set GORM logger level from app config and disable colors

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686b37e1f23c832aa720cb583b5df093