### PR TITLE
Log SQL queries only in debug mode

### DIFF
--- a/internal/utils/database/database.go
+++ b/internal/utils/database/database.go
@@ -14,11 +14,11 @@ import (
 )
 
 func NewDatabase(cfg *config.Config) (*gorm.DB, error) {
-	level := gormLogger.Warn
+	var level gormLogger.LogLevel
 	switch strings.ToLower(cfg.Server.LogLevel) {
 	case "debug":
 		level = gormLogger.Info
-		logging.DefaultLogger().Warn("DEBUG level set: SQL queries will be logged and may contain sensitive data")
+		logging.DefaultLogger().Error("DEBUG level set: SQL queries will be logged and may contain sensitive data")
 	case "warn", "warning":
 		level = gormLogger.Warn
 	case "error":

--- a/internal/utils/database/database.go
+++ b/internal/utils/database/database.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"dkhalife.com/tasks/core/config"
+	"dkhalife.com/tasks/core/internal/services/logging"
 	"github.com/glebarez/sqlite"
 	"gorm.io/gorm"
 	gormLogger "gorm.io/gorm/logger"
@@ -15,14 +16,17 @@ import (
 func NewDatabase(cfg *config.Config) (*gorm.DB, error) {
 	level := gormLogger.Warn
 	switch strings.ToLower(cfg.Server.LogLevel) {
-	case "debug", "info":
+	case "debug":
 		level = gormLogger.Info
+		logging.DefaultLogger().Warn("DEBUG level set: SQL queries will be logged and may contain sensitive data")
 	case "warn", "warning":
 		level = gormLogger.Warn
 	case "error":
 		level = gormLogger.Error
 	case "silent":
 		level = gormLogger.Silent
+	default:
+		level = gormLogger.Warn
 	}
 
 	logger := gormLogger.New(


### PR DESCRIPTION
## Summary
- disable DB query logging unless in debug mode
- add explicit warning when query logging is enabled
- document log level config
- restore README log level description

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686c847a921c832a889cc63a4e78f36a