### PR TITLE
Add websocket support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/gin-contrib/cors v1.7.2
 	github.com/gin-gonic/gin v1.10.0
 	github.com/glebarez/sqlite v1.11.0
+	github.com/gorilla/websocket v1.5.3
 	github.com/spf13/viper v1.19.0
 	github.com/ulule/limiter/v3 v3.11.2
 	go.uber.org/fx v1.22.0

--- a/go.sum
+++ b/go.sum
@@ -51,6 +51,8 @@ github.com/google/pprof v0.0.0-20240409012703-83162a5b38cd h1:gbpYu9NMq8jhDVbvlG
 github.com/google/pprof v0.0.0-20240409012703-83162a5b38cd/go.mod h1:kf6iHlnVGwgKolg33glAes7Yg/8iWP8ukqeldJSO7jw=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/jinzhu/inflection v1.0.0 h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD/E=

--- a/internal/ws/server.go
+++ b/internal/ws/server.go
@@ -72,7 +72,11 @@ func (s *WSServer) listen(ctx context.Context, wsConn *websocket.Conn) {
 
 	for {
 		if _, _, err := wsConn.ReadMessage(); err != nil {
-			logging.FromContext(ctx).Errorf("websocket read error: %v", err)
+			if websocket.IsCloseError(err, websocket.CloseNormalClosure, websocket.CloseGoingAway) {
+				logging.FromContext(ctx).Debugf("websocket connection closed: %v", err)
+			} else {
+				logging.FromContext(ctx).Errorf("websocket read error: %v", err)
+			}
 			return
 		}
 	}

--- a/internal/ws/server.go
+++ b/internal/ws/server.go
@@ -1,0 +1,84 @@
+package ws
+
+import (
+	"context"
+	"net/http"
+	"sync"
+
+	"dkhalife.com/tasks/core/internal/models"
+	"dkhalife.com/tasks/core/internal/services/logging"
+	authutil "dkhalife.com/tasks/core/internal/utils/auth"
+	jwt "github.com/appleboy/gin-jwt/v2"
+	"github.com/gin-gonic/gin"
+	"github.com/gorilla/websocket"
+)
+
+// connection represents a single websocket connection with associated identity.
+type connection struct {
+	ws       *websocket.Conn
+	identity *models.SignedInIdentity
+}
+
+// WSServer keeps track of active websocket connections.
+type WSServer struct {
+	upgrader    websocket.Upgrader
+	mu          sync.Mutex
+	connections map[*websocket.Conn]*connection
+}
+
+// NewWSServer creates a new websocket server instance.
+func NewWSServer() *WSServer {
+	return &WSServer{
+		upgrader: websocket.Upgrader{
+			ReadBufferSize:  1024,
+			WriteBufferSize: 1024,
+			CheckOrigin:     func(r *http.Request) bool { return true },
+		},
+		connections: make(map[*websocket.Conn]*connection),
+	}
+}
+
+// HandleConnection upgrades an HTTP request to a WebSocket connection and stores the
+// associated SignedInIdentity on success.
+func (s *WSServer) HandleConnection(c *gin.Context) {
+	identity := authutil.CurrentIdentity(c)
+	if identity == nil {
+		c.AbortWithStatus(http.StatusUnauthorized)
+		return
+	}
+
+	wsConn, err := s.upgrader.Upgrade(c.Writer, c.Request, nil)
+	if err != nil {
+		logging.FromContext(c).Errorf("websocket upgrade error: %v", err)
+		return
+	}
+
+	s.mu.Lock()
+	s.connections[wsConn] = &connection{ws: wsConn, identity: identity}
+	s.mu.Unlock()
+
+	go s.listen(c, wsConn)
+}
+
+// listen waits for messages on a connection and removes it when closed.
+func (s *WSServer) listen(ctx context.Context, wsConn *websocket.Conn) {
+	defer func() {
+		logging.FromContext(ctx).Debugf("cleaning up websocket connection")
+		wsConn.Close()
+		s.mu.Lock()
+		delete(s.connections, wsConn)
+		s.mu.Unlock()
+	}()
+
+	for {
+		if _, _, err := wsConn.ReadMessage(); err != nil {
+			logging.FromContext(ctx).Errorf("websocket read error: %v", err)
+			return
+		}
+	}
+}
+
+// Routes registers WebSocket routes.
+func Routes(router *gin.Engine, s *WSServer, auth *jwt.GinJWTMiddleware) {
+	router.GET("/api/ws", auth.MiddlewareFunc(), s.HandleConnection)
+}

--- a/internal/ws/server_test.go
+++ b/internal/ws/server_test.go
@@ -1,0 +1,67 @@
+package ws
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"dkhalife.com/tasks/core/internal/models"
+	auth "dkhalife.com/tasks/core/internal/utils/auth"
+	"github.com/gin-gonic/gin"
+	"github.com/gorilla/websocket"
+	"github.com/stretchr/testify/suite"
+)
+
+// WSServerTestSuite defines test suite for websocket server.
+type WSServerTestSuite struct {
+	suite.Suite
+	router *gin.Engine
+	server *WSServer
+}
+
+func TestWSServerTestSuite(t *testing.T) {
+	suite.Run(t, new(WSServerTestSuite))
+}
+
+func (s *WSServerTestSuite) SetupTest() {
+	gin.SetMode(gin.TestMode)
+	s.server = NewWSServer()
+	s.router = gin.New()
+	s.router.Use(func(c *gin.Context) {
+		if c.GetHeader("X-Test-Auth") == "true" {
+			c.Set(auth.IdentityKey, &models.SignedInIdentity{UserID: 1})
+		}
+	})
+	s.router.GET("/ws", s.server.HandleConnection)
+}
+
+func (s *WSServerTestSuite) TestHandleConnection_Unauthorized() {
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/ws", nil)
+
+	s.router.ServeHTTP(w, req)
+
+	s.Equal(http.StatusUnauthorized, w.Code)
+	s.Equal(0, len(s.server.connections))
+}
+
+func (s *WSServerTestSuite) TestHandleConnection_Authorized() {
+	ts := httptest.NewServer(s.router)
+	defer ts.Close()
+
+	url := "ws" + strings.TrimPrefix(ts.URL, "http") + "/ws"
+	header := http.Header{}
+	header.Set("X-Test-Auth", "true")
+
+	conn, resp, err := websocket.DefaultDialer.Dial(url, header)
+	s.Require().NoError(err)
+	s.Equal(http.StatusSwitchingProtocols, resp.StatusCode)
+	s.Equal(1, len(s.server.connections))
+
+	conn.Close()
+	time.Sleep(50 * time.Millisecond)
+
+	s.Equal(0, len(s.server.connections))
+}

--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ import (
 	database "dkhalife.com/tasks/core/internal/utils/database"
 	"dkhalife.com/tasks/core/internal/utils/email"
 	utils "dkhalife.com/tasks/core/internal/utils/middleware"
+	ws "dkhalife.com/tasks/core/internal/ws"
 	"github.com/gin-contrib/cors"
 	"github.com/gin-gonic/gin"
 	"go.uber.org/fx"
@@ -75,6 +76,7 @@ func main() {
 		fx.Provide(email.NewEmailSender),
 		// add handlers also
 		fx.Provide(newServer),
+		fx.Provide(ws.NewWSServer),
 		fx.Provide(scheduler.NewScheduler),
 
 		// Labels:
@@ -93,6 +95,7 @@ func main() {
 			apis.LabelRoutes,
 			apis.CalDAVRoutes,
 			apis.LogRoutes,
+			ws.Routes,
 			frontend.Routes,
 			backend.Routes,
 		),


### PR DESCRIPTION
## Summary
- add gorilla/websocket to go.mod
- implement a basic WebSocket server with authentication check
- expose `/api/ws` endpoint in main.go
- ensure server creation tests pass with updated signature
- add tests verifying unauthenticated WebSocket connection rejection and connection lifecycle

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686cb1126a64832abdf9e64f12cc6d34