### PR TITLE
Add user connection tracking and ping handling

### DIFF
--- a/internal/ws/server.go
+++ b/internal/ws/server.go
@@ -76,9 +76,14 @@ func (s *WSServer) HandleConnection(c *gin.Context) {
 // listen waits for messages on a connection and removes it when closed.
 func (s *WSServer) listen(ctx context.Context, conn *connection) {
 	wsConn := conn.ws
-	wsConn.SetReadDeadline(time.Now().Add(s.pongWait))
+	if err := wsConn.SetReadDeadline(time.Now().Add(s.pongWait)); err != nil {
+		logging.FromContext(ctx).Errorf("set read deadline error: %v", err)
+	}
 	wsConn.SetPongHandler(func(string) error {
-		return wsConn.SetReadDeadline(time.Now().Add(s.pongWait))
+		if err := wsConn.SetReadDeadline(time.Now().Add(s.pongWait)); err != nil {
+			logging.FromContext(ctx).Errorf("set read deadline error: %v", err)
+		}
+		return nil
 	})
 
 	ticker := time.NewTicker(s.pingPeriod)

--- a/internal/ws/server.go
+++ b/internal/ws/server.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"sync"
+	"time"
 
 	"dkhalife.com/tasks/core/internal/models"
 	"dkhalife.com/tasks/core/internal/services/logging"
@@ -21,9 +22,12 @@ type connection struct {
 
 // WSServer keeps track of active websocket connections.
 type WSServer struct {
-	upgrader    websocket.Upgrader
-	mu          sync.Mutex
-	connections map[*websocket.Conn]*connection
+	upgrader        websocket.Upgrader
+	mu              sync.Mutex
+	connections     map[*websocket.Conn]*connection
+	userConnections map[int]map[*websocket.Conn]*connection
+	pingPeriod      time.Duration
+	pongWait        time.Duration
 }
 
 // NewWSServer creates a new websocket server instance.
@@ -34,7 +38,10 @@ func NewWSServer() *WSServer {
 			WriteBufferSize: 1024,
 			CheckOrigin:     func(r *http.Request) bool { return true },
 		},
-		connections: make(map[*websocket.Conn]*connection),
+		connections:     make(map[*websocket.Conn]*connection),
+		userConnections: make(map[int]map[*websocket.Conn]*connection),
+		pongWait:        60 * time.Second,
+		pingPeriod:      54 * time.Second,
 	}
 }
 
@@ -53,20 +60,58 @@ func (s *WSServer) HandleConnection(c *gin.Context) {
 		return
 	}
 
+	conn := &connection{ws: wsConn, identity: identity}
+
 	s.mu.Lock()
-	s.connections[wsConn] = &connection{ws: wsConn, identity: identity}
+	s.connections[wsConn] = conn
+	if s.userConnections[identity.UserID] == nil {
+		s.userConnections[identity.UserID] = make(map[*websocket.Conn]*connection)
+	}
+	s.userConnections[identity.UserID][wsConn] = conn
 	s.mu.Unlock()
 
-	go s.listen(c, wsConn)
+	go s.listen(c, conn)
 }
 
 // listen waits for messages on a connection and removes it when closed.
-func (s *WSServer) listen(ctx context.Context, wsConn *websocket.Conn) {
+func (s *WSServer) listen(ctx context.Context, conn *connection) {
+	wsConn := conn.ws
+	wsConn.SetReadDeadline(time.Now().Add(s.pongWait))
+	wsConn.SetPongHandler(func(string) error {
+		return wsConn.SetReadDeadline(time.Now().Add(s.pongWait))
+	})
+
+	ticker := time.NewTicker(s.pingPeriod)
+	done := make(chan struct{})
+
+	go func() {
+		for {
+			select {
+			case <-ticker.C:
+				if err := wsConn.WriteMessage(websocket.PingMessage, nil); err != nil {
+					logging.FromContext(ctx).Errorf("websocket ping error: %v", err)
+					wsConn.Close()
+					return
+				}
+			case <-done:
+				return
+			}
+		}
+	}()
+
 	defer func() {
+		close(done)
+		ticker.Stop()
 		logging.FromContext(ctx).Debugf("cleaning up websocket connection")
 		wsConn.Close()
 		s.mu.Lock()
 		delete(s.connections, wsConn)
+		if uMap, ok := s.userConnections[conn.identity.UserID]; ok {
+			delete(uMap, wsConn)
+			if len(uMap) == 0 {
+				delete(s.userConnections, conn.identity.UserID)
+			}
+		}
 		s.mu.Unlock()
 	}()
 

--- a/internal/ws/server_test.go
+++ b/internal/ws/server_test.go
@@ -37,6 +37,21 @@ func (s *WSServerTestSuite) SetupTest() {
 	s.router.GET("/ws", s.server.HandleConnection)
 }
 
+func (s *WSServerTestSuite) dial(ts *httptest.Server) (*websocket.Conn, *http.Response, error) {
+	url := "ws" + strings.TrimPrefix(ts.URL, "http") + "/ws"
+	header := http.Header{}
+	header.Set("X-Test-Auth", "true")
+	return websocket.DefaultDialer.Dial(url, header)
+}
+
+func (s *WSServerTestSuite) waitForConnections(n int) {
+	s.Eventually(func() bool {
+		s.server.mu.Lock()
+		defer s.server.mu.Unlock()
+		return len(s.server.connections) == n
+	}, time.Second, 10*time.Millisecond)
+}
+
 func (s *WSServerTestSuite) TestHandleConnection_Unauthorized() {
 	w := httptest.NewRecorder()
 	req, _ := http.NewRequest(http.MethodGet, "/ws", nil)
@@ -51,20 +66,14 @@ func (s *WSServerTestSuite) TestHandleConnection_Authorized() {
 	ts := httptest.NewServer(s.router)
 	defer ts.Close()
 
-	url := "ws" + strings.TrimPrefix(ts.URL, "http") + "/ws"
-	header := http.Header{}
-	header.Set("X-Test-Auth", "true")
-
-	conn, resp, err := websocket.DefaultDialer.Dial(url, header)
+	conn, resp, err := s.dial(ts)
 	s.Require().NoError(err)
 	s.Equal(http.StatusSwitchingProtocols, resp.StatusCode)
-	s.Equal(1, len(s.server.connections))
+	s.waitForConnections(1)
 	s.Equal(1, len(s.server.userConnections))
 
 	conn.Close()
-	time.Sleep(50 * time.Millisecond)
-
-	s.Equal(0, len(s.server.connections))
+	s.waitForConnections(0)
 	s.Equal(0, len(s.server.userConnections))
 }
 
@@ -72,24 +81,18 @@ func (s *WSServerTestSuite) TestMultipleConnectionsAndCleanup() {
 	ts := httptest.NewServer(s.router)
 	defer ts.Close()
 
-	url := "ws" + strings.TrimPrefix(ts.URL, "http") + "/ws"
-	header := http.Header{}
-	header.Set("X-Test-Auth", "true")
-
-	conn1, _, err := websocket.DefaultDialer.Dial(url, header)
+	conn1, _, err := s.dial(ts)
 	s.Require().NoError(err)
-	conn2, _, err := websocket.DefaultDialer.Dial(url, header)
+	conn2, _, err := s.dial(ts)
 	s.Require().NoError(err)
 
-	s.Equal(2, len(s.server.connections))
+	s.waitForConnections(2)
 	s.Equal(1, len(s.server.userConnections))
 	s.Equal(2, len(s.server.userConnections[1]))
 
 	conn1.Close()
 	conn2.Close()
-	time.Sleep(50 * time.Millisecond)
-
-	s.Equal(0, len(s.server.connections))
+	s.waitForConnections(0)
 	s.Equal(0, len(s.server.userConnections))
 }
 
@@ -100,11 +103,7 @@ func (s *WSServerTestSuite) TestPingPongKeepsConnectionAlive() {
 	ts := httptest.NewServer(s.router)
 	defer ts.Close()
 
-	url := "ws" + strings.TrimPrefix(ts.URL, "http") + "/ws"
-	header := http.Header{}
-	header.Set("X-Test-Auth", "true")
-
-	conn, _, err := websocket.DefaultDialer.Dial(url, header)
+	conn, _, err := s.dial(ts)
 	s.Require().NoError(err)
 
 	go func() {
@@ -119,7 +118,5 @@ func (s *WSServerTestSuite) TestPingPongKeepsConnectionAlive() {
 	s.Equal(1, len(s.server.connections))
 
 	conn.Close()
-	time.Sleep(50 * time.Millisecond)
-
-	s.Equal(0, len(s.server.connections))
+	s.waitForConnections(0)
 }


### PR DESCRIPTION
## Summary
- extend `WSServer` with user connection tracking
- clean up user map when connections close
- add ping/pong keepalive logic
- test multi-connection cleanup and ping/pong

## Testing
- `go test ./internal/ws -run TestWSServerTestSuite -count=1`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686cba47fd24832a9382135c810eddcd