### PR TITLE
Enforce JWT secret configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,9 +72,9 @@ Make sure to replace `/path/to/host` with your preferred root directory for conf
 
 ## ⚙️ Configuration
 
-In the [config](./config/) directory are a couple of starter configuration files for prod and a dev environments. The server expects a config.yaml in the config directory and will load settings from it when started.
+In the [config](./config/) directory are a couple of starter configuration files for prod and dev environments. The server expects a config.yaml in the config directory and will load settings from it when started.
 
-**Note:** You can set `email.host`, `email.port`, `email.email`, `email.password` and `jwt.secret` using environment variables `TW_EMAIL_HOST`, `TW_EMAIL_PORT`, `TW_EMAIL_SENDER`, `TW_EMAIL_PASSWORD` and `TW_JWT_SECRET` for improved security and flexibility.
+**Note:** You can set `email.host`, `email.port`, `email.email`, `email.password` and `jwt.secret` using environment variables `TW_EMAIL_HOST`, `TW_EMAIL_PORT`, `TW_EMAIL_SENDER`, `TW_EMAIL_PASSWORD` and `TW_JWT_SECRET` for improved security and flexibility. The server will fail to start if `jwt.secret` is left as `"secret"`, so be sure to set `TW_JWT_SECRET` or edit `config.yaml`.
 
 The configuration files are yaml mappings with the following values:
 
@@ -83,7 +83,7 @@ The configuration files are yaml mappings with the following values:
 | `name`                                   | `"prod"`                                            | The name of the environment configuration.                                  |
 | `database.migration`                     | `true`                                              | Indicates if database migration should be performed.                        |
 | `database.path`                          | `/config/task-wizard.db`                            | The path at which to store the SQLite database.                             |
-| `jwt.secret`                             | `"secret"`                                          | The secret key used for signing JWT tokens. **Make sure to change that.**   |
+| `jwt.secret`                             | `"secret"`                                          | The secret key used for signing JWT tokens. **Make sure to change that or set `TW_JWT_SECRET`.**   |
 | `jwt.session_time`                       | `168h`                                              | The duration for which a JWT session is valid.                              |
 | `jwt.max_refresh`                        | `168h`                                              | The maximum duration for refreshing a JWT session.                          |
 | `server.host_name`                       | `localhost`                                         | The hostname to use for external links.                                     |

--- a/config/config.go
+++ b/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"log"
 	"time"
 
 	"github.com/spf13/viper"
@@ -74,6 +75,10 @@ func LoadConfig() *Config {
 	err = viper.Unmarshal(&config)
 	if err != nil {
 		panic(err)
+	}
+
+	if config.Jwt.Secret == "secret" {
+		log.Fatal("JWT secret must be changed from the default 'secret'. Set TW_JWT_SECRET or update config.yaml")
 	}
 
 	return &config

--- a/config/config.go
+++ b/config/config.go
@@ -1,8 +1,7 @@
 package config
 
 import (
-	"log"
-	"time"
+       "time"
 
 	"github.com/spf13/viper"
 )
@@ -77,9 +76,9 @@ func LoadConfig() *Config {
 		panic(err)
 	}
 
-	if config.Jwt.Secret == "secret" {
-		log.Fatal("JWT secret must be changed from the default 'secret'. Set TW_JWT_SECRET or update config.yaml")
-	}
+       if config.Jwt.Secret == "secret" {
+               panic("JWT secret must be changed from the default 'secret'. Set TW_JWT_SECRET or update config.yaml")
+       }
 
 	return &config
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -103,6 +103,7 @@ jwt:
 	os.Setenv("TW_EMAIL_PORT", "2525")
 	os.Setenv("TW_EMAIL_SENDER", "override@example.com")
 	os.Setenv("TW_EMAIL_PASSWORD", "overridepass")
+	os.Setenv("TW_JWT_SECRET", "s3cret")
 
 	viper.Reset()
 	cfg := LoadConfig()
@@ -116,4 +117,5 @@ jwt:
 	os.Unsetenv("TW_EMAIL_PORT")
 	os.Unsetenv("TW_EMAIL_SENDER")
 	os.Unsetenv("TW_EMAIL_PASSWORD")
+	os.Unsetenv("TW_JWT_SECRET")
 }


### PR DESCRIPTION
## Summary
- fail startup when the JWT secret is left as the default
- document mandatory `TW_JWT_SECRET`/config change
- update config tests to provide a custom secret

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6871d91d7c58832ab0ddfcb3bff39c60