### PR TITLE
Sanitize CalDAV titles

### DIFF
--- a/internal/repos/caldav/caldav.go
+++ b/internal/repos/caldav/caldav.go
@@ -81,6 +81,7 @@ func generateVTODO(task *models.Task) string {
 	// Sanitize the task title for iCalendar compatibility
 	sanitizedTitle := strings.ReplaceAll(task.Title, "\r", "")
 	sanitizedTitle = strings.ReplaceAll(sanitizedTitle, "\n", "")
+	sanitizedTitle = strings.ReplaceAll(sanitizedTitle, "\\", "\\\\")
 	sanitizedTitle = strings.ReplaceAll(sanitizedTitle, ",", "\\,")
 	sanitizedTitle = strings.ReplaceAll(sanitizedTitle, ";", "\\;")
 

--- a/internal/repos/caldav/caldav.go
+++ b/internal/repos/caldav/caldav.go
@@ -78,6 +78,12 @@ func generateCategories(task *models.Task) string {
 func generateVTODO(task *models.Task) string {
 	created := task.CreatedAt.UTC().Format("20060102T150405Z")
 
+	// Sanitize the task title for iCalendar compatibility
+	sanitizedTitle := strings.ReplaceAll(task.Title, "\r", "")
+	sanitizedTitle = strings.ReplaceAll(sanitizedTitle, "\n", "")
+	sanitizedTitle = strings.ReplaceAll(sanitizedTitle, ",", "\\,")
+	sanitizedTitle = strings.ReplaceAll(sanitizedTitle, ";", "\\;")
+
 	var lastModified string
 	if task.UpdatedAt != nil {
 		lastModified = task.UpdatedAt.UTC().Format("20060102T150405Z")
@@ -114,7 +120,7 @@ END:VCALENDAR`,
 		lastModified,
 		lastModified,
 		task.ID,
-		task.Title,
+		sanitizedTitle,
 		dueDate,
 		categories)
 

--- a/internal/repos/caldav/caldav_test.go
+++ b/internal/repos/caldav/caldav_test.go
@@ -33,3 +33,15 @@ func TestGenerateVTODO_TitleSpecialChars(t *testing.T) {
 
 	require.Contains(t, vtodo, "SUMMARY:Task\\;with\\,chars")
 }
+
+func TestGenerateVTODO_TitleBackslash(t *testing.T) {
+	task := &models.Task{
+		ID:        3,
+		Title:     "Back\\slash",
+		CreatedAt: time.Date(2023, 1, 2, 3, 4, 5, 0, time.UTC),
+	}
+
+	vtodo := generateVTODO(task)
+
+	require.Contains(t, vtodo, "SUMMARY:Back\\\\slash")
+}

--- a/internal/repos/caldav/caldav_test.go
+++ b/internal/repos/caldav/caldav_test.go
@@ -1,0 +1,35 @@
+package caldav
+
+import (
+	"testing"
+	"time"
+
+	"dkhalife.com/tasks/core/internal/models"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenerateVTODO_TitleNewline(t *testing.T) {
+	task := &models.Task{
+		ID:        1,
+		Title:     "Line1\nLine2\rLine3",
+		CreatedAt: time.Date(2023, 1, 2, 3, 4, 5, 0, time.UTC),
+	}
+
+	vtodo := generateVTODO(task)
+
+	require.Contains(t, vtodo, "SUMMARY:Line1Line2Line3")
+	require.NotContains(t, vtodo, "Line1\nLine2")
+	require.NotContains(t, vtodo, "\r")
+}
+
+func TestGenerateVTODO_TitleSpecialChars(t *testing.T) {
+	task := &models.Task{
+		ID:        2,
+		Title:     "Task;with,chars",
+		CreatedAt: time.Date(2023, 1, 2, 3, 4, 5, 0, time.UTC),
+	}
+
+	vtodo := generateVTODO(task)
+
+	require.Contains(t, vtodo, "SUMMARY:Task\\;with\\,chars")
+}


### PR DESCRIPTION
## Summary
- sanitize task titles by removing CR/LF and escaping commas and semicolons before generating iCalendar VTODO content
- add unit tests ensuring newline removal and special character escaping

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6871d9424b7c832a859195d1ae197437