### PR TITLE
Remove secretkey header from CORS config

### DIFF
--- a/main.go
+++ b/main.go
@@ -126,7 +126,7 @@ func newServer(lc fx.Lifecycle, cfg *config.Config, db *gorm.DB, bgScheduler *sc
 	config := cors.DefaultConfig()
 	config.AllowAllOrigins = true
 	config.AllowCredentials = true
-	config.AddAllowHeaders("Authorization", "secretkey")
+	config.AddAllowHeaders("Authorization")
 	r.Use(cors.New(config))
 	r.Use(utils.RequestLogger())
 


### PR DESCRIPTION
## Summary
- remove unused `secretkey` header from CORS configuration

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6871da5335b0832aa3de0de9e2354bc3