### PR TITLE
Improve rate limiter error handling

### DIFF
--- a/internal/utils/middleware/middleware.go
+++ b/internal/utils/middleware/middleware.go
@@ -35,7 +35,8 @@ func RateLimitMiddleware(limiter *limiter.Limiter) gin.HandlerFunc {
 		// Use the IP as the key, which is the client IP.
 		context, err := limiter.Get(c.Request.Context(), c.ClientIP())
 		if err != nil {
-			panic(err)
+			c.AbortWithStatus(http.StatusInternalServerError)
+			return
 		}
 
 		if context.Reached {

--- a/internal/utils/middleware/middleware_test.go
+++ b/internal/utils/middleware/middleware_test.go
@@ -1,6 +1,8 @@
 package middleware
 
 import (
+	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -9,6 +11,7 @@ import (
 	"dkhalife.com/tasks/core/config"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/suite"
+	"github.com/ulule/limiter/v3"
 )
 
 type MiddlewareTestSuite struct {
@@ -47,4 +50,44 @@ func (s *MiddlewareTestSuite) TestRateLimitMiddleware() {
 	w = httptest.NewRecorder()
 	s.router.ServeHTTP(w, req)
 	s.Equal(http.StatusTooManyRequests, w.Code)
+}
+
+// failingStore is a limiter store that always returns an error.
+type failingStore struct{}
+
+func (f *failingStore) Get(ctx context.Context, key string, rate limiter.Rate) (limiter.Context, error) {
+	return limiter.Context{}, errors.New("store failure")
+}
+
+func (f *failingStore) Peek(ctx context.Context, key string, rate limiter.Rate) (limiter.Context, error) {
+	return limiter.Context{}, errors.New("store failure")
+}
+
+func (f *failingStore) Reset(ctx context.Context, key string, rate limiter.Rate) (limiter.Context, error) {
+	return limiter.Context{}, errors.New("store failure")
+}
+
+func (f *failingStore) Increment(ctx context.Context, key string, count int64, rate limiter.Rate) (limiter.Context, error) {
+	return limiter.Context{}, errors.New("store failure")
+}
+
+func (s *MiddlewareTestSuite) TestRateLimitMiddlewareStoreFailure() {
+	cfg := &config.Config{
+		Server: config.ServerConfig{
+			RateLimit:  1,
+			RatePeriod: time.Hour,
+		},
+	}
+	store := &failingStore{}
+	limit := limiter.New(store, limiter.Rate{Period: cfg.Server.RatePeriod, Limit: int64(cfg.Server.RateLimit)})
+
+	s.router.Use(RateLimitMiddleware(limit))
+	s.router.GET("/", func(c *gin.Context) {
+		c.String(http.StatusOK, "OK")
+	})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/", nil)
+	s.router.ServeHTTP(w, req)
+	s.Equal(http.StatusInternalServerError, w.Code)
 }


### PR DESCRIPTION
## Summary
- handle limiter store errors in `RateLimitMiddleware`
- add failing store and corresponding tests
- return HTTP 500 without body on limiter failure

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6871da55d8dc832a976e79baa7df0084