### PR TITLE
Make CORS options configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ The configuration files are yaml mappings with the following values:
 | `server.serve_frontend`                  | `true`                                              | Indicates if the frontend should be served by the backend server.           |
 | `server.registration`                    | `true`                                              | Indicates whether new accounts can be created on the backend server.        |
 | `server.log_level`                       | `debug` when `server.debug` = `true`, else `warn`   | The min level to log (debug, info, warn, error, dpanic, panic, fatal).      |
+| `server.allowed_origins`                 | (empty) | Origins allowed to issue cross-domain requests. |
+| `server.allow_credentials`               | `false`                 | Whether cross-domain requests can include credentials. |
 | `scheduler_jobs.due_frequency`           | `5m`                                                | The interval for sending regular notifications.                             |
 | `scheduler_jobs.overdue_frequency`       | `24h`                                               | The interval for sending overdue notifications.                             |
 | `scheduler_jobs.password_reset_validity` | `24h`                                               | How long password reset tokens are valid for.                               |

--- a/README.md
+++ b/README.md
@@ -95,8 +95,8 @@ The configuration files are yaml mappings with the following values:
 | `server.serve_frontend`                  | `true`                                              | Indicates if the frontend should be served by the backend server.           |
 | `server.registration`                    | `true`                                              | Indicates whether new accounts can be created on the backend server.        |
 | `server.log_level`                       | `debug` when `server.debug` = `true`, else `warn`   | The min level to log (debug, info, warn, error, dpanic, panic, fatal).      |
-| `server.allowed_origins`                 | (empty) | Origins allowed to issue cross-domain requests. |
-| `server.allow_credentials`               | `false`                 | Whether cross-domain requests can include credentials. |
+| `server.allowed_origins`                 | `(empty)`                                           | Origins allowed to issue cross-domain requests.                             |
+| `server.allow_credentials`               | `false`                                             | Whether cross-domain requests can include credentials.                      |
 | `scheduler_jobs.due_frequency`           | `5m`                                                | The interval for sending regular notifications.                             |
 | `scheduler_jobs.overdue_frequency`       | `24h`                                               | The interval for sending overdue notifications.                             |
 | `scheduler_jobs.password_reset_validity` | `24h`                                               | How long password reset tokens are valid for.                               |

--- a/config/config.dev.yaml
+++ b/config/config.dev.yaml
@@ -17,7 +17,7 @@ server:
   log_level: "debug"
   allowed_origins:
     - http://localhost:5173
-  allow_credentials: true
+  allow_cors_credentials: true
 scheduler_jobs:
   due_frequency: 1m
   overdue_frequency: 1m

--- a/config/config.dev.yaml
+++ b/config/config.dev.yaml
@@ -15,6 +15,9 @@ server:
   serve_frontend: false
   registration: true
   log_level: "debug"
+  allowed_origins:
+    - http://localhost:5173
+  allow_credentials: false
 scheduler_jobs:
   due_frequency: 1m
   overdue_frequency: 1m

--- a/config/config.dev.yaml
+++ b/config/config.dev.yaml
@@ -17,7 +17,7 @@ server:
   log_level: "debug"
   allowed_origins:
     - http://localhost:5173
-  allow_credentials: false
+  allow_credentials: true
 scheduler_jobs:
   due_frequency: 1m
   overdue_frequency: 1m

--- a/config/config.go
+++ b/config/config.go
@@ -26,15 +26,17 @@ type JwtConfig struct {
 }
 
 type ServerConfig struct {
-	HostName      string        `mapstructure:"host_name" yaml:"host_name"`
-	Port          int           `mapstructure:"port" yaml:"port"`
-	RatePeriod    time.Duration `mapstructure:"rate_period" yaml:"rate_period"`
-	RateLimit     int           `mapstructure:"rate_limit" yaml:"rate_limit"`
-	ReadTimeout   time.Duration `mapstructure:"read_timeout" yaml:"read_timeout"`
-	WriteTimeout  time.Duration `mapstructure:"write_timeout" yaml:"write_timeout"`
-	ServeFrontend bool          `mapstructure:"serve_frontend" yaml:"serve_frontend"`
-	Registration  bool          `mapstructure:"registration" yaml:"registration"`
-	LogLevel      string        `mapstructure:"log_level" yaml:"log_level"`
+	HostName         string        `mapstructure:"host_name" yaml:"host_name"`
+	Port             int           `mapstructure:"port" yaml:"port"`
+	RatePeriod       time.Duration `mapstructure:"rate_period" yaml:"rate_period"`
+	RateLimit        int           `mapstructure:"rate_limit" yaml:"rate_limit"`
+	ReadTimeout      time.Duration `mapstructure:"read_timeout" yaml:"read_timeout"`
+	WriteTimeout     time.Duration `mapstructure:"write_timeout" yaml:"write_timeout"`
+	ServeFrontend    bool          `mapstructure:"serve_frontend" yaml:"serve_frontend"`
+	Registration     bool          `mapstructure:"registration" yaml:"registration"`
+	LogLevel         string        `mapstructure:"log_level" yaml:"log_level"`
+	AllowedOrigins   []string      `mapstructure:"allowed_origins" yaml:"allowed_origins"`
+	AllowCredentials bool          `mapstructure:"allow_credentials" yaml:"allow_credentials"`
 }
 
 type SchedulerConfig struct {

--- a/config/config.go
+++ b/config/config.go
@@ -1,7 +1,7 @@
 package config
 
 import (
-       "time"
+	"time"
 
 	"github.com/spf13/viper"
 )
@@ -26,17 +26,17 @@ type JwtConfig struct {
 }
 
 type ServerConfig struct {
-	HostName         string        `mapstructure:"host_name" yaml:"host_name"`
-	Port             int           `mapstructure:"port" yaml:"port"`
-	RatePeriod       time.Duration `mapstructure:"rate_period" yaml:"rate_period"`
-	RateLimit        int           `mapstructure:"rate_limit" yaml:"rate_limit"`
-	ReadTimeout      time.Duration `mapstructure:"read_timeout" yaml:"read_timeout"`
-	WriteTimeout     time.Duration `mapstructure:"write_timeout" yaml:"write_timeout"`
-	ServeFrontend    bool          `mapstructure:"serve_frontend" yaml:"serve_frontend"`
-	Registration     bool          `mapstructure:"registration" yaml:"registration"`
-	LogLevel         string        `mapstructure:"log_level" yaml:"log_level"`
-	AllowedOrigins   []string      `mapstructure:"allowed_origins" yaml:"allowed_origins"`
-	AllowCredentials bool          `mapstructure:"allow_credentials" yaml:"allow_credentials"`
+	HostName             string        `mapstructure:"host_name" yaml:"host_name"`
+	Port                 int           `mapstructure:"port" yaml:"port"`
+	RatePeriod           time.Duration `mapstructure:"rate_period" yaml:"rate_period"`
+	RateLimit            int           `mapstructure:"rate_limit" yaml:"rate_limit"`
+	ReadTimeout          time.Duration `mapstructure:"read_timeout" yaml:"read_timeout"`
+	WriteTimeout         time.Duration `mapstructure:"write_timeout" yaml:"write_timeout"`
+	ServeFrontend        bool          `mapstructure:"serve_frontend" yaml:"serve_frontend"`
+	Registration         bool          `mapstructure:"registration" yaml:"registration"`
+	LogLevel             string        `mapstructure:"log_level" yaml:"log_level"`
+	AllowedOrigins       []string      `mapstructure:"allowed_origins" yaml:"allowed_origins"`
+	AllowCorsCredentials bool          `mapstructure:"allow_cors_credentials" yaml:"allow_cors_credentials"`
 }
 
 type SchedulerConfig struct {
@@ -78,9 +78,9 @@ func LoadConfig() *Config {
 		panic(err)
 	}
 
-       if config.Jwt.Secret == "secret" {
-               panic("JWT secret must be changed from the default 'secret'. Set TW_JWT_SECRET or update config.yaml")
-       }
+	if config.Jwt.Secret == "secret" {
+		panic("JWT secret must be changed from the default 'secret'. Set TW_JWT_SECRET or update config.yaml")
+	}
 
 	return &config
 }

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -15,7 +15,6 @@ server:
   serve_frontend: true
   registration: true
   log_level: "warn"
-  allow_credentials: false
 scheduler_jobs:
   due_frequency: 5m
   overdue_frequency: 24h

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -15,6 +15,7 @@ server:
   serve_frontend: true
   registration: true
   log_level: "warn"
+  allow_credentials: false
 scheduler_jobs:
   due_frequency: 5m
   overdue_frequency: 24h

--- a/main.go
+++ b/main.go
@@ -123,11 +123,15 @@ func newServer(lc fx.Lifecycle, cfg *config.Config, db *gorm.DB, bgScheduler *sc
 		ReadTimeout:  cfg.Server.ReadTimeout,
 		WriteTimeout: cfg.Server.WriteTimeout,
 	}
-	config := cors.DefaultConfig()
-	config.AllowAllOrigins = true
-	config.AllowCredentials = true
-	config.AddAllowHeaders("Authorization", "secretkey")
-	r.Use(cors.New(config))
+	if len(cfg.Server.AllowedOrigins) > 0 {
+		corsCfg := cors.DefaultConfig()
+		corsCfg.AllowOrigins = cfg.Server.AllowedOrigins
+		if cfg.Server.AllowCredentials {
+			corsCfg.AllowCredentials = true
+		}
+		corsCfg.AddAllowHeaders("Authorization", "secretkey")
+		r.Use(cors.New(corsCfg))
+	}
 	r.Use(utils.RequestLogger())
 
 	lc.Append(fx.Hook{

--- a/main.go
+++ b/main.go
@@ -126,7 +126,7 @@ func newServer(lc fx.Lifecycle, cfg *config.Config, db *gorm.DB, bgScheduler *sc
 	if len(cfg.Server.AllowedOrigins) > 0 {
 		corsCfg := cors.DefaultConfig()
 		corsCfg.AllowOrigins = cfg.Server.AllowedOrigins
-		if cfg.Server.AllowCredentials {
+		if cfg.Server.AllowCorsCredentials {
 			corsCfg.AllowCredentials = true
 		}
 		corsCfg.AddAllowHeaders("Authorization")


### PR DESCRIPTION
## Summary
- allow CORS origins and credentials to be configured via config file
- remove default localhost origin for production config
- only enable CORS middleware when AllowedOrigins is non-empty
- document default empty value for `server.allowed_origins`

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6871da636834832a9dabbb054650e3c8