### PR TITLE
Implement ws handler routing

### DIFF
--- a/internal/ws/server_test.go
+++ b/internal/ws/server_test.go
@@ -67,8 +67,8 @@ func (s *WSServerTestSuite) dial(ts *httptest.Server) (*websocket.Conn, *http.Re
 
 func (s *WSServerTestSuite) waitForConnections(n int) {
 	s.Eventually(func() bool {
-		s.server.mu.Lock()
-		defer s.server.mu.Unlock()
+		s.server.mu.RLock()
+		defer s.server.mu.RUnlock()
 		return len(s.server.connections) == n
 	}, time.Second, 10*time.Millisecond)
 }

--- a/internal/ws/server_test.go
+++ b/internal/ws/server_test.go
@@ -1,6 +1,8 @@
 package ws
 
 import (
+	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
@@ -156,4 +158,36 @@ func (s *WSServerTestSuite) TestPingPongKeepsConnectionAlive() {
 	conn.Close()
 	<-done // Wait for the reading goroutine to finish
 	s.waitForConnections(0)
+}
+
+func (s *WSServerTestSuite) TestRegisterHandler_DuplicatePanics() {
+	handler := func(ctx context.Context, conn *connection, msg WSMessage) (*WSResponse, error) {
+		return nil, nil
+	}
+
+	s.server.RegisterHandler("dup", handler)
+	s.Panics(func() { s.server.RegisterHandler("dup", handler) })
+}
+
+func (s *WSServerTestSuite) TestHandleMessageRoutesResponse() {
+	s.server.RegisterHandler("echo", func(ctx context.Context, conn *connection, msg WSMessage) (*WSResponse, error) {
+		return &WSResponse{Action: "echo", Data: msg.Data}, nil
+	})
+
+	ts := httptest.NewServer(s.router)
+	defer ts.Close()
+
+	conn, _, err := s.dial(ts)
+	s.Require().NoError(err)
+	defer conn.Close()
+
+	s.waitForConnections(1)
+
+	payload := WSMessage{Action: "echo", Data: json.RawMessage(`"hello"`)}
+	s.NoError(conn.WriteJSON(payload))
+
+	var resp WSResponse
+	s.NoError(conn.ReadJSON(&resp))
+	s.Equal("echo", resp.Action)
+	s.Equal("hello", resp.Data)
 }


### PR DESCRIPTION
## Summary
- enable registering websocket message handlers
- automatically route websocket messages to registered handlers
- test registering handlers and routing responses

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6872a5a42768832aa0aa0bc6a07a0c3f