### PR TITLE
Add notification types and websocket broadcast

### DIFF
--- a/internal/models/notification.go
+++ b/internal/models/notification.go
@@ -5,13 +5,14 @@ import (
 )
 
 type Notification struct {
-	ID           int       `json:"id" gorm:"primaryKey"`
-	TaskID       int       `json:"task_id" gorm:"column:task_id;not null;index:idx_notifications_task_id"`
-	UserID       int       `json:"user_id" gorm:"column:user_id;not null;index:idx_notifications_user_id"`
-	Text         string    `json:"text" gorm:"column:text;not null"`
-	IsSent       bool      `json:"is_sent" gorm:"column:is_sent;index;default:false"`
-	ScheduledFor time.Time `json:"scheduled_for" gorm:"column:scheduled_for;not null;index"`
-	CreatedAt    time.Time `json:"created_at" gorm:"column:created_at;default:CURRENT_TIMESTAMP"`
+	ID           int              `json:"id" gorm:"primaryKey"`
+	TaskID       int              `json:"task_id" gorm:"column:task_id;not null;index:idx_notifications_task_id"`
+	UserID       int              `json:"user_id" gorm:"column:user_id;not null;index:idx_notifications_user_id"`
+	Text         string           `json:"text" gorm:"column:text;not null"`
+	Type         NotificationType `json:"type" gorm:"type:varchar(8);column:type;not null"`
+	IsSent       bool             `json:"is_sent" gorm:"column:is_sent;index;default:false"`
+	ScheduledFor time.Time        `json:"scheduled_for" gorm:"column:scheduled_for;not null;index"`
+	CreatedAt    time.Time        `json:"created_at" gorm:"column:created_at;default:CURRENT_TIMESTAMP"`
 
 	Task Task `json:"-" gorm:"foreignKey:TaskID"`
 	User User `json:"-" gorm:"foreignKey:UserID"`
@@ -23,6 +24,14 @@ const (
 	NotificationProviderNone    NotificationProviderType = "none"
 	NotificationProviderWebhook NotificationProviderType = "webhook"
 	NotificationProviderGotify  NotificationProviderType = "gotify"
+)
+
+type NotificationType string
+
+const (
+	NotificationTypeDueDate NotificationType = "due_date"
+	NotificationTypePreDue  NotificationType = "pre_due"
+	NotificationTypeOverdue NotificationType = "overdue"
 )
 
 type NotificationProvider struct {

--- a/internal/repos/notifier/notifier.go
+++ b/internal/repos/notifier/notifier.go
@@ -80,6 +80,7 @@ func (r *NotificationRepository) GenerateNotifications(c context.Context, task *
 		notifications = append(notifications, models.Notification{
 			TaskID:       task.ID,
 			UserID:       task.CreatedBy,
+			Type:         models.NotificationTypeDueDate,
 			IsSent:       false,
 			ScheduledFor: *task.NextDueDate,
 			Text:         fmt.Sprintf("📅 *%s* is due", task.Title),
@@ -90,6 +91,7 @@ func (r *NotificationRepository) GenerateNotifications(c context.Context, task *
 		notifications = append(notifications, models.Notification{
 			TaskID:       task.ID,
 			UserID:       task.CreatedBy,
+			Type:         models.NotificationTypePreDue,
 			IsSent:       false,
 			ScheduledFor: task.NextDueDate.Add(-time.Hour * 3),
 			Text:         fmt.Sprintf("📢 *%s* is coming up on %s", task.Title, task.NextDueDate.Format("January 2nd")),

--- a/internal/repos/notifier/notifier_test.go
+++ b/internal/repos/notifier/notifier_test.go
@@ -85,6 +85,7 @@ func (s *NotifierTestSuite) TestBatchInsertNotifications() {
 		{
 			TaskID:       s.testTask.ID,
 			UserID:       s.testUser.ID,
+			Type:         models.NotificationTypeDueDate,
 			IsSent:       false,
 			ScheduledFor: now,
 			Text:         "Test notification 1",
@@ -92,6 +93,7 @@ func (s *NotifierTestSuite) TestBatchInsertNotifications() {
 		{
 			TaskID:       s.testTask.ID,
 			UserID:       s.testUser.ID,
+			Type:         models.NotificationTypePreDue,
 			IsSent:       false,
 			ScheduledFor: now.Add(1 * time.Hour),
 			Text:         "Test notification 2",
@@ -138,12 +140,14 @@ func (s *NotifierTestSuite) TestGenerateNotifications() {
 	s.NotNil(dueDateNotification)
 	s.Equal(s.testTask.ID, dueDateNotification.TaskID)
 	s.Equal(s.testUser.ID, dueDateNotification.UserID)
+	s.Equal(models.NotificationTypeDueDate, dueDateNotification.Type)
 	s.Equal(false, dueDateNotification.IsSent)
 
 	// Verify pre-due notification
 	s.NotNil(preDueNotification)
 	s.Equal(s.testTask.ID, preDueNotification.TaskID)
 	s.Equal(s.testUser.ID, preDueNotification.UserID)
+	s.Equal(models.NotificationTypePreDue, preDueNotification.Type)
 	s.Equal(false, preDueNotification.IsSent)
 	s.Equal(s.testTask.NextDueDate.Add(-3*time.Hour).Unix(), preDueNotification.ScheduledFor.Unix())
 }
@@ -155,6 +159,7 @@ func (s *NotifierTestSuite) TestMarkNotificationsAsSent() {
 		{
 			TaskID:       s.testTask.ID,
 			UserID:       s.testUser.ID,
+			Type:         models.NotificationTypeDueDate,
 			IsSent:       false,
 			ScheduledFor: now,
 			Text:         "Test notification 1",
@@ -162,6 +167,7 @@ func (s *NotifierTestSuite) TestMarkNotificationsAsSent() {
 		{
 			TaskID:       s.testTask.ID,
 			UserID:       s.testUser.ID,
+			Type:         models.NotificationTypePreDue,
 			IsSent:       false,
 			ScheduledFor: now.Add(1 * time.Hour),
 			Text:         "Test notification 2",
@@ -189,6 +195,7 @@ func (s *NotifierTestSuite) TestGetPendingNotification() {
 		{
 			TaskID:       s.testTask.ID,
 			UserID:       s.testUser.ID,
+			Type:         models.NotificationTypeDueDate,
 			IsSent:       false,
 			ScheduledFor: now.Add(-1 * time.Hour), // This one is pending (scheduled in the past)
 			Text:         "Pending notification",
@@ -196,6 +203,7 @@ func (s *NotifierTestSuite) TestGetPendingNotification() {
 		{
 			TaskID:       s.testTask.ID,
 			UserID:       s.testUser.ID,
+			Type:         models.NotificationTypePreDue,
 			IsSent:       true, // Already sent
 			ScheduledFor: now.Add(-2 * time.Hour),
 			Text:         "Already sent notification",
@@ -203,6 +211,7 @@ func (s *NotifierTestSuite) TestGetPendingNotification() {
 		{
 			TaskID:       s.testTask.ID,
 			UserID:       s.testUser.ID,
+			Type:         models.NotificationTypePreDue,
 			IsSent:       false,
 			ScheduledFor: now.Add(1 * time.Hour), // Future notification
 			Text:         "Future notification",
@@ -216,6 +225,7 @@ func (s *NotifierTestSuite) TestGetPendingNotification() {
 	s.Require().NoError(err)
 	s.Require().Len(pending, 1)
 	s.Equal("Pending notification", pending[0].Text)
+	s.Equal(models.NotificationTypeDueDate, pending[0].Type)
 }
 
 func (s *NotifierTestSuite) TestGetOverdueTasksWithNotifications() {
@@ -301,6 +311,7 @@ func (s *NotifierTestSuite) TestDeleteSentNotifications() {
 		{
 			TaskID:       s.testTask.ID,
 			UserID:       s.testUser.ID,
+			Type:         models.NotificationTypeDueDate,
 			IsSent:       true,                     // Already sent
 			ScheduledFor: now.Add(-48 * time.Hour), // Old notification
 			Text:         "Old sent notification",
@@ -308,6 +319,7 @@ func (s *NotifierTestSuite) TestDeleteSentNotifications() {
 		{
 			TaskID:       s.testTask.ID,
 			UserID:       s.testUser.ID,
+			Type:         models.NotificationTypeDueDate,
 			IsSent:       true,                    // Already sent
 			ScheduledFor: now.Add(-1 * time.Hour), // Recent notification
 			Text:         "Recent sent notification",
@@ -315,6 +327,7 @@ func (s *NotifierTestSuite) TestDeleteSentNotifications() {
 		{
 			TaskID:       s.testTask.ID,
 			UserID:       s.testUser.ID,
+			Type:         models.NotificationTypeDueDate,
 			IsSent:       false,                    // Not sent
 			ScheduledFor: now.Add(-72 * time.Hour), // Old notification but not sent
 			Text:         "Old unsent notification",

--- a/internal/services/notifications/notifications.go
+++ b/internal/services/notifications/notifications.go
@@ -8,35 +8,45 @@ import (
 	"dkhalife.com/tasks/core/config"
 	"dkhalife.com/tasks/core/internal/models"
 	"dkhalife.com/tasks/core/internal/services/logging"
+	"dkhalife.com/tasks/core/internal/ws"
+	"github.com/gin-gonic/gin"
 
 	nRepo "dkhalife.com/tasks/core/internal/repos/notifier"
 )
 
 func (n *Notifier) sendNotification(c context.Context, notification *models.Notification) error {
+	var err error
 	switch notification.User.NotificationSettings.Provider.Provider {
-	case models.NotificationProviderNone:
-		return nil
-
 	case models.NotificationProviderWebhook:
-		return SendNotificationViaWebhook(c, notification.User.NotificationSettings.Provider, notification.Text)
-
+		err = SendNotificationViaWebhook(c, notification.User.NotificationSettings.Provider, notification.Text)
+		break
 	case models.NotificationProviderGotify:
-		return SendNotificationViaGotify(c, notification.User.NotificationSettings.Provider, notification.Text)
-
+		err = SendNotificationViaGotify(c, notification.User.NotificationSettings.Provider, notification.Text)
+		break
 	}
 
-	return nil
+	n.ws.BroadcastToUser(notification.UserID, ws.WSResponse{
+		Action: "notification",
+		Data: gin.H{
+			"task_id": notification.TaskID,
+			"type":    notification.Type,
+		},
+	})
+
+	return err
 }
 
 type Notifier struct {
 	DueFrequency time.Duration
 	nRepo        *nRepo.NotificationRepository
+	ws           *ws.WSServer
 }
 
-func NewNotifier(cfg *config.Config, nr *nRepo.NotificationRepository) *Notifier {
+func NewNotifier(cfg *config.Config, nr *nRepo.NotificationRepository, ws *ws.WSServer) *Notifier {
 	return &Notifier{
 		DueFrequency: cfg.SchedulerJobs.DueFrequency,
 		nRepo:        nr,
+		ws:           ws,
 	}
 }
 
@@ -137,6 +147,7 @@ func (n *Notifier) GenerateOverdueNotifications(c context.Context) error {
 		overdueNotification := models.Notification{
 			TaskID:       task.ID,
 			UserID:       task.CreatedBy,
+			Type:         models.NotificationTypeOverdue,
 			IsSent:       false,
 			ScheduledFor: startTime,
 			Text:         fmt.Sprintf("🚨 *%s* is overdue", task.Title),

--- a/internal/services/notifications/notifications.go
+++ b/internal/services/notifications/notifications.go
@@ -19,10 +19,8 @@ func (n *Notifier) sendNotification(c context.Context, notification *models.Noti
 	switch notification.User.NotificationSettings.Provider.Provider {
 	case models.NotificationProviderWebhook:
 		err = SendNotificationViaWebhook(c, notification.User.NotificationSettings.Provider, notification.Text)
-		break
 	case models.NotificationProviderGotify:
 		err = SendNotificationViaGotify(c, notification.User.NotificationSettings.Provider, notification.Text)
-		break
 	}
 
 	n.ws.BroadcastToUser(notification.UserID, ws.WSResponse{


### PR DESCRIPTION
## Summary
- add `NotificationType` enum and store notification `Type`
- tag notifications when generating them
- broadcast notifications over websockets with minimal payload
- inject websocket server into notifier service
- adjust repository tests for new field
- break switch cases in `sendNotification`

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6872c2a274b0832a89a28266e6cd55fb