### PR TITLE
Remove config param from backend handler

### DIFF
--- a/backend/handler.go
+++ b/backend/handler.go
@@ -3,7 +3,6 @@ package backend
 import (
 	"net/http"
 
-	"dkhalife.com/tasks/core/config"
 	uRepo "dkhalife.com/tasks/core/internal/repos/user"
 	"dkhalife.com/tasks/core/internal/utils/auth"
 	"dkhalife.com/tasks/core/internal/utils/middleware"
@@ -15,7 +14,7 @@ type Handler struct {
 	uRepo uRepo.IUserRepo
 }
 
-func NewHandler(config *config.Config, uRepo uRepo.IUserRepo) *Handler {
+func NewHandler(uRepo uRepo.IUserRepo) *Handler {
 	return &Handler{
 		uRepo,
 	}


### PR DESCRIPTION
## Summary
- drop unused `config *config.Config` parameter from `backend.NewHandler`
- update provider wiring to use the simplified signature

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6872cd97be14832aaf76bea827418d80