### PR TITLE
Refactor logger and cleanup middleware

### DIFF
--- a/internal/services/logging/logging.go
+++ b/internal/services/logging/logging.go
@@ -40,8 +40,8 @@ func SetConfig(c *Config) {
 	}
 }
 
-// NewLogger creates a new logger with the given log level
-func NewLogger(conf *Config) *zap.SugaredLogger {
+// newLogger creates a new logger with the given log level
+func newLogger(conf *Config) *zap.SugaredLogger {
 	ec := zap.NewProductionEncoderConfig()
 	ec.EncodeTime = zapcore.ISO8601TimeEncoder
 	cfg := zap.Config{
@@ -68,7 +68,7 @@ func NewLogger(conf *Config) *zap.SugaredLogger {
 
 func DefaultLogger() *zap.SugaredLogger {
 	defaultLoggerOnce.Do(func() {
-		defaultLogger = NewLogger(conf)
+		defaultLogger = newLogger(conf)
 	})
 	return defaultLogger
 }

--- a/internal/services/logging/logging_test.go
+++ b/internal/services/logging/logging_test.go
@@ -16,7 +16,7 @@ func TestSetConfigAndNewLogger(t *testing.T) {
 		Development: true,
 	}
 	SetConfig(cfg)
-	logger := NewLogger(cfg)
+	logger := newLogger(cfg)
 	assert.NotNil(t, logger)
 	logger.Debug("debug message")
 }

--- a/internal/utils/middleware/middleware.go
+++ b/internal/utils/middleware/middleware.go
@@ -1,22 +1,16 @@
 package middleware
 
 import (
-	"context"
 	"encoding/base64"
 	"net/http"
 	"strconv"
 	"strings"
-	"time"
 
 	"dkhalife.com/tasks/core/config"
 	"dkhalife.com/tasks/core/internal/services/logging"
 	"github.com/gin-gonic/gin"
 	"github.com/ulule/limiter/v3"
 	"github.com/ulule/limiter/v3/drivers/store/memory"
-)
-
-const (
-	XRequestIdKey = "X-Request-ID"
 )
 
 func NewRateLimiter(cfg *config.Config) *limiter.Limiter {
@@ -47,21 +41,6 @@ func RateLimitMiddleware(limiter *limiter.Limiter) gin.HandlerFunc {
 		c.Header("X-RateLimit-Limit", strconv.FormatInt(context.Limit, 10))
 		c.Header("X-RateLimit-Remaining", strconv.FormatInt(context.Remaining, 10))
 		c.Header("X-RateLimit-Reset", strconv.FormatInt(context.Reset, 10))
-		c.Next()
-	}
-}
-
-func TimeoutMiddleware(timeout time.Duration) gin.HandlerFunc {
-	return func(c *gin.Context) {
-		ctx, cancel := context.WithTimeout(c.Request.Context(), timeout)
-
-		defer func() {
-			if ctx.Err() == context.DeadlineExceeded {
-				c.AbortWithStatus(http.StatusGatewayTimeout)
-			}
-			cancel()
-		}()
-		c.Request = c.Request.WithContext(ctx)
 		c.Next()
 	}
 }


### PR DESCRIPTION
## Summary
- make `NewLogger` private as `newLogger`
- remove unused `XRequestIdKey` constant and `TimeoutMiddleware`
- update tests

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6872ce04ea04832a858954c4f3422a26