### PR TITLE
Remove unused jwtAuth from Users API

### DIFF
--- a/internal/apis/user.go
+++ b/internal/apis/user.go
@@ -26,16 +26,14 @@ type UsersAPIHandler struct {
 	userRepo    uRepo.IUserRepo
 	userService *users.UserService
 	nRepo       *nRepo.NotificationRepository
-	jwtAuth     *jwt.GinJWTMiddleware
 	email       email.IEmailSender
 }
 
-func UsersAPI(ur uRepo.IUserRepo, nRepo *nRepo.NotificationRepository, us *users.UserService, jwtAuth *jwt.GinJWTMiddleware, email email.IEmailSender, config *config.Config) *UsersAPIHandler {
+func UsersAPI(ur uRepo.IUserRepo, nRepo *nRepo.NotificationRepository, us *users.UserService, email email.IEmailSender, config *config.Config) *UsersAPIHandler {
 	return &UsersAPIHandler{
 		userRepo:    ur,
 		userService: us,
 		nRepo:       nRepo,
-		jwtAuth:     jwtAuth,
 		email:       email,
 	}
 }


### PR DESCRIPTION
## Summary
- remove `jwtAuth` field from `UsersAPIHandler`
- update `UsersAPI` constructor signature

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6872cd896a74832a93fce39d16fdbffc