### PR TITLE
Stop scheduler on server shutdown

### DIFF
--- a/main.go
+++ b/main.go
@@ -166,6 +166,8 @@ func newServer(lc fx.Lifecycle, cfg *config.Config, db *gorm.DB, bgScheduler *sc
 			return nil
 		},
 		OnStop: func(ctx context.Context) error {
+			bgScheduler.Stop()
+
 			if err := srv.Shutdown(ctx); err != nil {
 				log := logging.FromContext(ctx)
 				log.Fatalf("Server Shutdown: %s", err)


### PR DESCRIPTION
## Summary
- ensure scheduler is stopped when the server stops

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6872cf4f1fb8832a87a9bdcfca83dba9