### PR TITLE
Remove unused scheduler keys

### DIFF
--- a/internal/services/scheduler/scheduler.go
+++ b/internal/services/scheduler/scheduler.go
@@ -10,12 +10,6 @@ import (
 	"dkhalife.com/tasks/core/internal/services/notifications"
 )
 
-type keyType string
-
-const (
-	SchedulerKey keyType = "scheduler"
-)
-
 type Scheduler struct {
 	stopChan             chan bool
 	notifier             *notifications.Notifier


### PR DESCRIPTION
## Summary
- clean up unused scheduler context key definitions
- restore required `Stop()` method

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6872cdc70c68832aa0543f7a66a2b42f