### PR TITLE
Handle body read errors in CalDAV redirect

### DIFF
--- a/internal/apis/caldav.go
+++ b/internal/apis/caldav.go
@@ -273,7 +273,13 @@ func (h *CalDAVAPIHandler) handleRootRedirect(c *gin.Context) {
 	// Save the request body for forwarding
 	var bodyBytes []byte
 	if c.Request.Body != nil {
-		bodyBytes, _ = io.ReadAll(c.Request.Body)
+		var err error
+		bodyBytes, err = io.ReadAll(c.Request.Body)
+		if err != nil {
+			log.Errorf("Error reading request body: %s", err.Error())
+			c.AbortWithStatus(http.StatusInternalServerError)
+			return
+		}
 		c.Request.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
 	}
 


### PR DESCRIPTION
## Summary
- improve request body reading in `handleRootRedirect`
- log failures and abort with 500 if body can't be read

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6872d7865cd8832abdb677402f505d22