### PR TITLE
Add request ID to websocket types

### DIFF
--- a/internal/ws/message.go
+++ b/internal/ws/message.go
@@ -4,13 +4,15 @@ import "encoding/json"
 
 // WSMessage represents a request coming from the websocket client.
 type WSMessage struct {
-	Action string          `json:"action"`
-	Data   json.RawMessage `json:"data,omitempty"`
+	RequestID string          `json:"requestId"`
+	Action    string          `json:"action"`
+	Data      json.RawMessage `json:"data,omitempty"`
 }
 
 // WSResponse represents a message sent back to the client.
 type WSResponse struct {
-	Action string      `json:"action"`
-	Status int         `json:"status"`
-	Data   interface{} `json:"data,omitempty"`
+	RequestID string      `json:"requestId,omitempty"`
+	Action    string      `json:"action"`
+	Status    int         `json:"status"`
+	Data      interface{} `json:"data,omitempty"`
 }

--- a/internal/ws/server.go
+++ b/internal/ws/server.go
@@ -307,6 +307,7 @@ func (s *WSServer) handleMessage(ctx context.Context, conn *connection, msg WSMe
 	}
 
 	resp.Action = msg.Action
+	resp.RequestID = msg.RequestID
 
 	if err := conn.safeWriteJSON(resp); err != nil {
 		log.Errorf("failed to write JSON to WebSocket: %v", err)

--- a/internal/ws/server_test.go
+++ b/internal/ws/server_test.go
@@ -186,11 +186,12 @@ func (s *WSServerTestSuite) TestHandleMessageRoutesResponse() {
 
 	s.waitForConnections(1)
 
-	payload := WSMessage{Action: "echo", Data: json.RawMessage(`"hello"`)}
+	payload := WSMessage{RequestID: "1", Action: "echo", Data: json.RawMessage(`"hello"`)}
 	s.NoError(conn.WriteJSON(payload))
 
 	var resp WSResponse
 	s.NoError(conn.ReadJSON(&resp))
+	s.Equal("1", resp.RequestID)
 	s.Equal("echo", resp.Action)
 	s.Equal("hello", resp.Data)
 }


### PR DESCRIPTION
## Summary
- include `RequestID` in `WSMessage` and `WSResponse`
- echo `RequestID` back in `handleMessage`
- update websocket tests

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6872f9621188832ab5871a4ddebebfb7