### PR TITLE
Fix missing labels in task websocket messages

### DIFF
--- a/internal/services/tasks/task.go
+++ b/internal/services/tasks/task.go
@@ -148,6 +148,12 @@ func (s *TaskService) CreateTask(ctx context.Context, userID int, req models.Cre
 		}
 	}
 
+	labels := make([]models.Label, len(req.Labels))
+	for i, id := range req.Labels {
+		labels[i] = models.Label{ID: id}
+	}
+	createdTask.Labels = labels
+
 	go func(task *models.Task, logger *zap.SugaredLogger) {
 		ctx := logging.ContextWithLogger(context.Background(), logger)
 		s.n.GenerateNotifications(ctx, task)
@@ -235,6 +241,12 @@ func (s *TaskService) EditTask(ctx context.Context, userID int, req models.Updat
 			"error": "Error upserting task",
 		}
 	}
+
+	labels := make([]models.Label, len(req.Labels))
+	for i, id := range req.Labels {
+		labels[i] = models.Label{ID: id}
+	}
+	updatedTask.Labels = labels
 
 	go func(task *models.Task, logger *zap.SugaredLogger) {
 		ctx := logging.ContextWithLogger(context.Background(), logger)


### PR DESCRIPTION
## Summary
- ensure created tasks include label IDs in websocket broadcasts without reloading from DB
- populate updated tasks with label IDs before broadcast to avoid extra queries

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a20b8e329c832ab96939b1189ef5f6