### PR TITLE
Prevent rendering in an iframe

### DIFF
--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -37,12 +37,14 @@ window.onunhandledrejection = async (event) => {
   }
 }
 
-ReactDOM.createRoot(useRoot()).render(
-  <React.StrictMode>
-    <ErrorBoundary>
-      <Provider store={store}>
-        <RouterContext />
-      </Provider>
-    </ErrorBoundary>
-  </React.StrictMode>,
-)
+if (window.self === window.top) {
+  ReactDOM.createRoot(useRoot()).render(
+    <React.StrictMode>
+      <ErrorBoundary>
+        <Provider store={store}>
+          <RouterContext />
+        </Provider>
+      </ErrorBoundary>
+    </React.StrictMode>,
+  )
+}


### PR DESCRIPTION
MSAL's silent login uses iframe that redirect to / which renders the app within them, over and over again