### PR TITLE
Add task search by title + better MCP tool error messages

### DIFF
--- a/apiserver/internal/apis/task.go
+++ b/apiserver/internal/apis/task.go
@@ -3,6 +3,7 @@ package apis
 import (
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	authMW "dkhalife.com/tasks/core/internal/middleware/auth"
@@ -70,6 +71,22 @@ func (h *TasksAPIHandler) getTasksByLabel(c *gin.Context) {
 	}
 
 	status, response := h.tService.GetTasksByLabel(c, currentIdentity.UserID, labelID)
+	c.JSON(status, response)
+}
+
+func (h *TasksAPIHandler) searchTasks(c *gin.Context) {
+	currentIdentity := auth.CurrentIdentity(c)
+
+	query := strings.TrimSpace(c.Query("q"))
+	if query == "" {
+		telemetry.TrackWarning(c, "task_invalid_param", "task-handler", "Missing 'q' query parameter", nil)
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "'q' query parameter is required",
+		})
+		return
+	}
+
+	status, response := h.tService.SearchTasksByTitle(c, currentIdentity.UserID, query)
 	c.JSON(status, response)
 }
 
@@ -275,6 +292,7 @@ func TaskRoutes(router *gin.Engine, h *TasksAPIHandler, auth *authMW.AuthMiddlew
 		tasksRoutes.GET("/", authMW.ScopeMiddleware(models.ApiTokenScopeTaskRead), h.getTasks)
 		tasksRoutes.GET("/due", authMW.ScopeMiddleware(models.ApiTokenScopeTaskRead), h.getTasksDueBefore)
 		tasksRoutes.GET("/label/:labelId", authMW.ScopeMiddleware(models.ApiTokenScopeTaskRead), h.getTasksByLabel)
+		tasksRoutes.GET("/search", authMW.ScopeMiddleware(models.ApiTokenScopeTaskRead), h.searchTasks)
 		tasksRoutes.GET("/completed", authMW.ScopeMiddleware(models.ApiTokenScopeTaskRead), h.getCompletedTasks)
 		tasksRoutes.PUT("/", authMW.ScopeMiddleware(models.ApiTokenScopeTaskWrite), h.editTask)
 		tasksRoutes.POST("/", authMW.ScopeMiddleware(models.ApiTokenScopeTaskWrite), h.createTask)

--- a/apiserver/internal/repos/task/task.go
+++ b/apiserver/internal/repos/task/task.go
@@ -87,13 +87,16 @@ func (r *TaskRepository) GetTasksByLabel(c context.Context, userID int, labelID 
 func (r *TaskRepository) SearchTasksByTitle(c context.Context, userID int, query string) ([]*models.Task, error) {
 	var tasks []*models.Task
 
-	escaped := strings.ReplaceAll(query, `\`, `\\`)
-	escaped = strings.ReplaceAll(escaped, "%", `\%`)
-	escaped = strings.ReplaceAll(escaped, "_", `\_`)
+	// Escape LIKE wildcards so they match literally. Use '!' as the escape
+	// character because backslash has dialect-specific meaning inside MySQL
+	// string literals by default and would produce a SQL syntax error.
+	escaped := strings.ReplaceAll(query, "!", "!!")
+	escaped = strings.ReplaceAll(escaped, "%", "!%")
+	escaped = strings.ReplaceAll(escaped, "_", "!_")
 	pattern := "%" + strings.ToLower(escaped) + "%"
 
 	if err := r.db.WithContext(c).
-		Where(`created_by = ? AND is_active = 1 AND LOWER(title) LIKE ? ESCAPE '\'`, userID, pattern).
+		Where("created_by = ? AND is_active = 1 AND LOWER(title) LIKE ? ESCAPE '!'", userID, pattern).
 		Order("next_due_date ASC").
 		Preload("Labels").
 		Find(&tasks).Error; err != nil {

--- a/apiserver/internal/repos/task/task.go
+++ b/apiserver/internal/repos/task/task.go
@@ -3,6 +3,7 @@ package repos
 import (
 	"context"
 	"errors"
+	"strings"
 	"time"
 
 	config "dkhalife.com/tasks/core/config"
@@ -74,6 +75,25 @@ func (r *TaskRepository) GetTasksByLabel(c context.Context, userID int, labelID 
 	if err := r.db.WithContext(c).
 		Where("created_by = ? AND is_active = 1", userID).
 		Joins("JOIN task_labels ON task_labels.task_id = tasks.id AND task_labels.label_id = ?", labelID).
+		Order("next_due_date ASC").
+		Preload("Labels").
+		Find(&tasks).Error; err != nil {
+		return nil, err
+	}
+
+	return tasks, nil
+}
+
+func (r *TaskRepository) SearchTasksByTitle(c context.Context, userID int, query string) ([]*models.Task, error) {
+	var tasks []*models.Task
+
+	escaped := strings.ReplaceAll(query, `\`, `\\`)
+	escaped = strings.ReplaceAll(escaped, "%", `\%`)
+	escaped = strings.ReplaceAll(escaped, "_", `\_`)
+	pattern := "%" + strings.ToLower(escaped) + "%"
+
+	if err := r.db.WithContext(c).
+		Where(`created_by = ? AND is_active = 1 AND LOWER(title) LIKE ? ESCAPE '\'`, userID, pattern).
 		Order("next_due_date ASC").
 		Preload("Labels").
 		Find(&tasks).Error; err != nil {

--- a/apiserver/internal/repos/task/task_test.go
+++ b/apiserver/internal/repos/task/task_test.go
@@ -801,3 +801,72 @@ func (s *TaskTestSuite) TestGetTasksByLabel() {
 	// All labels are preloaded (not just the filtered one)
 	s.Require().Len(result[1].Labels, 2)
 }
+
+func (s *TaskTestSuite) TestSearchTasksByTitle() {
+	ctx := context.Background()
+
+	now := time.Now().UTC()
+	due1 := now.Add(24 * time.Hour)
+	due2 := now.Add(48 * time.Hour)
+
+	groceries := &models.Task{
+		Title:       "Buy groceries",
+		CreatedBy:   s.testUser.ID,
+		NextDueDate: &due2,
+		IsActive:    true,
+		Frequency:   models.Frequency{Type: models.RepeatOnce},
+	}
+	s.Require().NoError(s.DB.Create(groceries).Error)
+
+	grocerySort := &models.Task{
+		Title:       "Sort Groceries in pantry",
+		CreatedBy:   s.testUser.ID,
+		NextDueDate: &due1,
+		IsActive:    true,
+		Frequency:   models.Frequency{Type: models.RepeatOnce},
+	}
+	s.Require().NoError(s.DB.Create(grocerySort).Error)
+
+	unrelated := &models.Task{
+		Title:       "Walk the dog",
+		CreatedBy:   s.testUser.ID,
+		NextDueDate: &due1,
+		IsActive:    true,
+		Frequency:   models.Frequency{Type: models.RepeatOnce},
+	}
+	s.Require().NoError(s.DB.Create(unrelated).Error)
+
+	inactive := &models.Task{
+		ID:          60,
+		Title:       "Old groceries list",
+		CreatedBy:   s.testUser.ID,
+		NextDueDate: &due1,
+		IsActive:    true,
+		Frequency:   models.Frequency{Type: models.RepeatOnce},
+	}
+	s.Require().NoError(s.DB.Create(inactive).Error)
+	s.Require().NoError(s.DB.Model(&models.Task{}).Where("id = ?", 60).Update("is_active", false).Error)
+
+	otherUser := &models.User{}
+	s.Require().NoError(s.DB.Create(otherUser).Error)
+	otherUserTask := &models.Task{
+		Title:       "Their groceries",
+		CreatedBy:   otherUser.ID,
+		NextDueDate: &due1,
+		IsActive:    true,
+		Frequency:   models.Frequency{Type: models.RepeatOnce},
+	}
+	s.Require().NoError(s.DB.Create(otherUserTask).Error)
+
+	// Case-insensitive, matches substring, only active tasks for this user
+	result, err := s.repo.SearchTasksByTitle(ctx, s.testUser.ID, "grocer")
+	s.Require().NoError(err)
+	s.Require().Len(result, 2)
+	s.Equal("Sort Groceries in pantry", result[0].Title)
+	s.Equal("Buy groceries", result[1].Title)
+
+	// LIKE wildcards in query are treated literally
+	resultLiteral, err := s.repo.SearchTasksByTitle(ctx, s.testUser.ID, "%")
+	s.Require().NoError(err)
+	s.Require().Len(resultLiteral, 0)
+}

--- a/apiserver/internal/services/tasks/task.go
+++ b/apiserver/internal/services/tasks/task.go
@@ -86,6 +86,22 @@ func (s *TaskService) GetTasksByLabel(ctx context.Context, userID int, labelID i
 	}
 }
 
+func (s *TaskService) SearchTasksByTitle(ctx context.Context, userID int, query string) (int, interface{}) {
+	log := logging.FromContext(ctx)
+	tasks, err := s.t.SearchTasksByTitle(ctx, userID, query)
+	if err != nil {
+		log.Errorf("error searching tasks by title %q: %s", query, err.Error())
+		telemetry.TrackError(ctx, "task_search_failed", "task-service", err, nil)
+		return http.StatusInternalServerError, gin.H{
+			"error": "Error searching tasks",
+		}
+	}
+
+	return http.StatusOK, gin.H{
+		"tasks": tasks,
+	}
+}
+
 func (s *TaskService) GetCompletedTasks(ctx context.Context, userID, limit, page int) (int, interface{}) {
 	log := logging.FromContext(ctx)
 	offset := (page - 1) * limit

--- a/mcpserver/Program.cs
+++ b/mcpserver/Program.cs
@@ -1,7 +1,10 @@
+using System.Text.Json;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.IdentityModel.Tokens;
+using ModelContextProtocol;
 using ModelContextProtocol.AspNetCore;
 using ModelContextProtocol.AspNetCore.Authentication;
+using ModelContextProtocol.Protocol;
 using TaskWizard.McpServer.Services;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -76,7 +79,46 @@ builder.Services.AddAuthorization();
 builder.Services
     .AddMcpServer()
     .WithHttpTransport()
-    .WithToolsFromAssembly();
+    .WithToolsFromAssembly()
+    .WithRequestFilters(filters => filters.AddCallToolFilter(next => async (context, cancellationToken) =>
+    {
+        try
+        {
+            return await next(context, cancellationToken);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (McpException)
+        {
+            // Already surfaced with a descriptive message by the SDK.
+            throw;
+        }
+        catch (JsonException ex)
+        {
+            var toolName = context.Params?.Name ?? "<unknown>";
+            var message =
+                $"Invalid arguments for tool '{toolName}': {ex.Message} " +
+                "Check that each argument matches the declared type in the tool schema " +
+                "(for example, booleans must be sent as true/false, not as quoted strings).";
+            return new CallToolResult
+            {
+                IsError = true,
+                Content = [new TextContentBlock { Text = message }],
+            };
+        }
+        catch (Exception ex)
+        {
+            var toolName = context.Params?.Name ?? "<unknown>";
+            var message = $"Tool '{toolName}' failed: {ex.GetType().Name}: {ex.Message}";
+            return new CallToolResult
+            {
+                IsError = true,
+                Content = [new TextContentBlock { Text = message }],
+            };
+        }
+    }));
 
 var app = builder.Build();
 

--- a/mcpserver/Program.cs
+++ b/mcpserver/Program.cs
@@ -86,7 +86,7 @@ builder.Services
         {
             return await next(context, cancellationToken);
         }
-        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        catch (OperationCanceledException)
         {
             throw;
         }

--- a/mcpserver/Services/ApiProxyService.cs
+++ b/mcpserver/Services/ApiProxyService.cs
@@ -63,6 +63,9 @@ public class ApiProxyService(IHttpClientFactory httpClientFactory, IHttpContextA
     public Task<string> GetTasksByLabel(int labelId) =>
         SendAsync(HttpMethod.Get, $"api/v1/tasks/label/{labelId}");
 
+    public Task<string> SearchTasksByTitle(string query) =>
+        SendAsync(HttpMethod.Get, $"api/v1/tasks/search?q={Uri.EscapeDataString(query)}");
+
     public Task<string> GetTask(int id) =>
         SendAsync(HttpMethod.Get, $"api/v1/tasks/{id}");
 

--- a/mcpserver/Tools/TaskTools.cs
+++ b/mcpserver/Tools/TaskTools.cs
@@ -109,4 +109,9 @@ public class TaskTools(ApiProxyService api)
     public Task<string> ListTasksByLabel(
         [Description("Label ID")] int labelId) =>
         api.GetTasksByLabel(labelId);
+
+    [McpServerTool, Description("Search active tasks by a case-insensitive substring of their title")]
+    public Task<string> SearchTasksByTitle(
+        [Description("Substring to match against task titles (case-insensitive)")] string query) =>
+        api.SearchTasksByTitle(query);
 }


### PR DESCRIPTION
## Changes

### Search tasks by title
- New `GET /api/v1/tasks/search?q=<substring>` endpoint (task-read scope).
- Case-insensitive substring match on active tasks; LIKE wildcards in `q` are escaped so `%`/`_` match literally.
- Added repo test `TestSearchTasksByTitle` covering case-insensitivity, user isolation, active-only filter, and literal wildcards.
- Exposed as new MCP tool `search_tasks_by_title` so agents can look up tasks by title instead of fetching the whole list.

### Better MCP tool error messages
Tool calls were failing with unhandled exceptions (e.g. `JsonException` when a client sent `isRolling` as a quoted string), bubbling up a generic error with no actionable info for the model.

- Added a `CallTool` request filter in `Program.cs` that wraps every tool invocation.
- `JsonException` (argument deserialization failures) now returns a `CallToolResult { IsError = true }` with a message that names the tool and hints that types must match the schema (e.g. booleans as `true`/`false`, not quoted strings).
- Other exceptions are surfaced with their type + message, letting the LLM self-correct on retry.
- `McpException` and cancellations are passed through unchanged.