### PR TITLE
Android: eliminate task list flicker on cold start

### DIFF
--- a/android/app/src/main/java/com/dkhalife/tasks/TaskWizardApplication.kt
+++ b/android/app/src/main/java/com/dkhalife/tasks/TaskWizardApplication.kt
@@ -8,6 +8,7 @@ import com.dkhalife.tasks.data.sync.SyncCoordinator
 import com.dkhalife.tasks.data.sync.TaskSyncWorkerFactory
 import com.dkhalife.tasks.data.sync.WebSocketLifecycleManager
 import com.dkhalife.tasks.telemetry.TelemetryManager
+import com.microsoft.identity.client.IAccount
 import com.microsoft.identity.client.IPublicClientApplication
 import com.microsoft.identity.client.ISingleAccountPublicClientApplication
 import com.microsoft.identity.client.PublicClientApplication
@@ -86,13 +87,13 @@ class TaskWizardApplication : Application(), Configuration.Provider {
 
     private fun loadCurrentAccount(app: ISingleAccountPublicClientApplication) {
         app.getCurrentAccountAsync(object : ISingleAccountPublicClientApplication.CurrentAccountCallback {
-            override fun onAccountLoaded(activeAccount: com.microsoft.identity.client.IAccount?) {
+            override fun onAccountLoaded(activeAccount: IAccount?) {
                 authManager.updateAccount(activeAccount)
             }
 
             override fun onAccountChanged(
-                priorAccount: com.microsoft.identity.client.IAccount?,
-                currentAccount: com.microsoft.identity.client.IAccount?
+                priorAccount: IAccount?,
+                currentAccount: IAccount?
             ) {
                 authManager.updateAccount(currentAccount)
             }

--- a/android/app/src/main/java/com/dkhalife/tasks/TaskWizardApplication.kt
+++ b/android/app/src/main/java/com/dkhalife/tasks/TaskWizardApplication.kt
@@ -49,6 +49,9 @@ class TaskWizardApplication : Application(), Configuration.Provider {
         initializeMsal()
         webSocketLifecycleManager.start()
         networkMonitor.addOnAvailableListener { syncCoordinator.syncOnce() }
+        if (networkMonitor.isOnline.value) {
+            syncCoordinator.syncOnce()
+        }
     }
 
     private fun setupCrashHandler() {

--- a/android/app/src/main/java/com/dkhalife/tasks/TaskWizardApplication.kt
+++ b/android/app/src/main/java/com/dkhalife/tasks/TaskWizardApplication.kt
@@ -48,7 +48,6 @@ class TaskWizardApplication : Application(), Configuration.Provider {
         initializeMsal()
         webSocketLifecycleManager.start()
         networkMonitor.addOnAvailableListener { syncCoordinator.syncOnce() }
-        syncCoordinator.syncOnce()
     }
 
     private fun setupCrashHandler() {

--- a/android/app/src/main/java/com/dkhalife/tasks/data/sync/SyncCoordinator.kt
+++ b/android/app/src/main/java/com/dkhalife/tasks/data/sync/SyncCoordinator.kt
@@ -1,7 +1,9 @@
 package com.dkhalife.tasks.data.sync
 
+import androidx.room.withTransaction
 import com.dkhalife.tasks.api.TaskWizardApi
 import com.dkhalife.tasks.data.db.LocalState
+import com.dkhalife.tasks.data.db.TaskWizardDatabase
 import com.dkhalife.tasks.data.db.dao.LabelDao
 import com.dkhalife.tasks.data.db.dao.OutboxDao
 import com.dkhalife.tasks.data.db.dao.TaskDao
@@ -40,6 +42,7 @@ import javax.inject.Singleton
 @Singleton
 class SyncCoordinator @Inject constructor(
     private val api: TaskWizardApi,
+    private val db: TaskWizardDatabase,
     private val taskDao: TaskDao,
     private val labelDao: LabelDao,
     private val outboxDao: OutboxDao,
@@ -326,8 +329,10 @@ class SyncCoordinator @Inject constructor(
     }
 
     private suspend fun refreshAll() {
-        refreshLabels()
-        refreshTasks()
+        db.withTransaction {
+            refreshLabels()
+            refreshTasks()
+        }
     }
 
     private suspend fun refreshTasks() {

--- a/android/app/src/main/java/com/dkhalife/tasks/data/sync/SyncCoordinator.kt
+++ b/android/app/src/main/java/com/dkhalife/tasks/data/sync/SyncCoordinator.kt
@@ -329,60 +329,80 @@ class SyncCoordinator @Inject constructor(
     }
 
     private suspend fun refreshAll() {
+        val labels = fetchLabelsForRefresh()
+        val tasks = fetchTasksForRefresh()
+        if (labels == null && tasks == null) return
         db.withTransaction {
-            refreshLabels()
-            refreshTasks()
+            labels?.let { applyLabelsToDb(it) }
+            tasks?.let { applyTasksToDb(it) }
         }
     }
 
-    private suspend fun refreshTasks() {
+    private suspend fun fetchTasksForRefresh(): List<TaskRefreshPayload>? {
         val response = api.getTasks()
         if (!response.isSuccessful) {
             telemetryManager.logWarning(TAG, "Refresh tasks failed: HTTP ${response.code()}")
-            return
+            return null
         }
-        val tasks = response.body()?.tasks ?: emptyList()
+        return response.body()?.tasks?.map { task ->
+            TaskRefreshPayload(
+                entity = task.toEntity(localState = LocalState.SYNCED),
+                labelIds = task.labels.map { it.id },
+            )
+        } ?: emptyList()
+    }
+
+    private suspend fun applyTasksToDb(tasks: List<TaskRefreshPayload>) {
         val dirtyIds = taskDao.dirtyIds().toSet()
-        val serverIds = tasks.map { it.id }.toSet()
+        val serverIds = tasks.map { it.entity.id }.toSet()
 
         taskDao.allIds()
             .filter { it !in serverIds && it !in dirtyIds }
             .forEach { taskDao.deleteById(it) }
 
-        for (t in tasks) {
-            if (t.id in dirtyIds) continue
-            taskDao.upsert(t.toEntity(localState = LocalState.SYNCED))
-            taskDao.replaceLabels(t.id, t.labels.map { it.id })
+        for (task in tasks) {
+            if (task.entity.id in dirtyIds) continue
+            taskDao.upsert(task.entity)
+            taskDao.replaceLabels(task.entity.id, task.labelIds)
         }
     }
 
-    private suspend fun refreshLabels() {
+    private suspend fun fetchLabelsForRefresh(): List<LabelEntity>? {
         val response = api.getLabels()
         if (!response.isSuccessful) {
             telemetryManager.logWarning(TAG, "Refresh labels failed: HTTP ${response.code()}")
-            return
+            return null
         }
-        val labels = response.body()?.labels ?: emptyList()
+        return response.body()?.labels?.map { label ->
+            LabelEntity(
+                id = label.id,
+                localId = null,
+                name = label.name,
+                color = label.color,
+                createdAt = label.createdAt,
+                updatedAt = label.updatedAt,
+                localState = LocalState.SYNCED,
+            )
+        } ?: emptyList()
+    }
+
+    private suspend fun applyLabelsToDb(labels: List<LabelEntity>) {
         val dirtyIds = labelDao.dirtyIds().toSet()
         val serverIds = labels.map { it.id }.toSet()
         labelDao.allIds()
             .filter { it !in serverIds && it !in dirtyIds }
             .forEach { labelDao.deleteById(it) }
-        for (l in labels) {
-            if (l.id in dirtyIds) continue
-            labelDao.upsert(
-                LabelEntity(
-                    id = l.id,
-                    localId = null,
-                    name = l.name,
-                    color = l.color,
-                    createdAt = l.createdAt,
-                    updatedAt = l.updatedAt,
-                    localState = LocalState.SYNCED,
-                )
-            )
+        for (label in labels) {
+            if (label.id in dirtyIds) continue
+            labelDao.upsert(label)
         }
     }
+
+    private data class TaskRefreshPayload(
+        val entity: TaskEntity,
+        val labelIds: List<Int>,
+    )
+
 
     companion object {
         private const val TAG = "SyncCoordinator"

--- a/android/app/src/main/java/com/dkhalife/tasks/viewmodel/TaskListViewModel.kt
+++ b/android/app/src/main/java/com/dkhalife/tasks/viewmodel/TaskListViewModel.kt
@@ -70,12 +70,6 @@ class TaskListViewModel @Inject constructor(
 
     init {
         refreshTasks()
-        viewModelScope.launch {
-            labelRepository.refreshLabels().onFailure {
-                telemetryManager.logError(TAG, "Failed to refresh labels: ${it.message}", it)
-                _error.value = it.message
-            }
-        }
         collectWebSocketMessages()
         observeGrouping()
     }


### PR DESCRIPTION
## Problem

When opening the Android app, the cached task list flashes multiple times before stabilizing: labels disappear and reappear, and the whole cycle repeats two or three times.

## Root causes

1. **Intra-refresh flicker** — `SyncCoordinator.refreshAll()` upserts tasks and replaces their label cross-refs one row at a time. `TaskDao.replaceLabels` does `DELETE FROM task_labels` then re-inserts; each write invalidates the `@Transaction @Query` backing `observeTasks()`, so the Flow emits intermediate states where tasks temporarily have no labels.
2. **Three refresh cycles per cold open** — all of these triggered a full `refreshAll()`:
   - `TaskWizardApplication.onCreate` → `syncCoordinator.syncOnce()`
   - `TaskListViewModel.init` → `refreshTasks()`
   - `TaskListViewModel.init` → `labelRepository.refreshLabels()` (which also just delegates to `syncOnceBlocking`)

   They serialize behind the coordinator mutex and each one produces its own flicker cycle.

## Fix

- Wrap `SyncCoordinator.refreshAll()` in `db.withTransaction { ... }` so Room batches table invalidations and emits a single Flow update per sync.
- Drop the redundant `labelRepository.refreshLabels()` call from `TaskListViewModel.init` — `refreshTasks()` already refreshes labels via the coordinator.
- Drop the eager `syncCoordinator.syncOnce()` from `TaskWizardApplication.onCreate`; the first screen's ViewModel triggers a refresh, and the `NetworkMonitor` availability listener still kicks one when connectivity flips on.

Net result on cold open: a single refresh cycle with a single UI update — no flash.
