### PR TITLE
android: optimistic UI for task complete and skip

### DIFF
--- a/android/app/src/main/java/com/dkhalife/tasks/api/TaskWizardApi.kt
+++ b/android/app/src/main/java/com/dkhalife/tasks/api/TaskWizardApi.kt
@@ -37,13 +37,13 @@ interface TaskWizardApi {
     suspend fun completeTask(
         @Path("id") id: Int,
         @Query("endRecurrence") endRecurrence: Boolean = false
-    ): Response<Void>
+    ): Response<TaskResponse>
 
     @POST("api/v1/tasks/{id}/undo")
-    suspend fun uncompleteTask(@Path("id") id: Int): Response<Void>
+    suspend fun uncompleteTask(@Path("id") id: Int): Response<TaskResponse>
 
     @POST("api/v1/tasks/{id}/skip")
-    suspend fun skipTask(@Path("id") id: Int): Response<Void>
+    suspend fun skipTask(@Path("id") id: Int): Response<TaskResponse>
 
     @PUT("api/v1/tasks/{id}/dueDate")
     suspend fun updateDueDate(

--- a/android/app/src/main/java/com/dkhalife/tasks/data/db/LocalState.kt
+++ b/android/app/src/main/java/com/dkhalife/tasks/data/db/LocalState.kt
@@ -5,4 +5,6 @@ object LocalState {
     const val PENDING_CREATE = "PENDING_CREATE"
     const val PENDING_UPDATE = "PENDING_UPDATE"
     const val PENDING_DELETE = "PENDING_DELETE"
+    const val PENDING_COMPLETE = "PENDING_COMPLETE"
+    const val PENDING_SKIP = "PENDING_SKIP"
 }

--- a/android/app/src/main/java/com/dkhalife/tasks/data/db/dao/TaskDao.kt
+++ b/android/app/src/main/java/com/dkhalife/tasks/data/db/dao/TaskDao.kt
@@ -13,7 +13,7 @@ import kotlinx.coroutines.flow.Flow
 @Dao
 interface TaskDao {
     @Transaction
-    @Query("SELECT * FROM tasks WHERE localState != 'PENDING_DELETE' ORDER BY id")
+    @Query("SELECT * FROM tasks WHERE localState NOT IN ('PENDING_DELETE', 'PENDING_COMPLETE', 'PENDING_SKIP') ORDER BY id")
     fun observeTasks(): Flow<List<TaskWithLabels>>
 
     @Transaction
@@ -36,7 +36,7 @@ interface TaskDao {
     @Query("UPDATE tasks SET localState = :state WHERE id = :id")
     suspend fun setState(id: Int, state: String)
 
-    @Query("UPDATE tasks SET id = :newId, localId = NULL, localState = 'SYNCED' WHERE id = :oldId")
+    @Query("UPDATE tasks SET id = :newId, localId = NULL, localState = CASE WHEN localState = 'PENDING_CREATE' THEN 'SYNCED' ELSE localState END WHERE id = :oldId")
     suspend fun remapId(oldId: Int, newId: Int)
 
     @Query("DELETE FROM tasks WHERE id = :id")

--- a/android/app/src/main/java/com/dkhalife/tasks/data/sync/SyncCoordinator.kt
+++ b/android/app/src/main/java/com/dkhalife/tasks/data/sync/SyncCoordinator.kt
@@ -231,10 +231,17 @@ class SyncCoordinator @Inject constructor(
                 val endRecurrence = op.payloadJson?.toBooleanStrictOrNull() ?: false
                 val response = api.completeTask(id, endRecurrence)
                 if (!response.isSuccessful) {
+                    taskDao.setState(id, LocalState.PENDING_UPDATE)
                     recordFailure(op, "HTTP ${response.code()}")
                     return false
                 }
-                taskDao.setState(id, LocalState.SYNCED)
+                val returnedTask = response.body()?.task
+                if (returnedTask?.nextDueDate != null) {
+                    taskDao.upsert(returnedTask.toEntity())
+                    taskDao.replaceLabels(id, returnedTask.labels.map { it.id })
+                } else {
+                    taskDao.deleteById(id)
+                }
                 outboxDao.deleteById(op.id)
             }
             OutboxOpType.UNCOMPLETE -> {
@@ -248,7 +255,13 @@ class SyncCoordinator @Inject constructor(
                     recordFailure(op, "HTTP ${response.code()}")
                     return false
                 }
-                taskDao.setState(id, LocalState.SYNCED)
+                val returnedTask = response.body()?.task
+                if (returnedTask != null) {
+                    taskDao.upsert(returnedTask.toEntity())
+                    taskDao.replaceLabels(id, returnedTask.labels.map { it.id })
+                } else {
+                    taskDao.setState(id, LocalState.SYNCED)
+                }
                 outboxDao.deleteById(op.id)
             }
             OutboxOpType.SKIP -> {
@@ -259,10 +272,17 @@ class SyncCoordinator @Inject constructor(
                 }
                 val response = api.skipTask(id)
                 if (!response.isSuccessful) {
+                    taskDao.setState(id, LocalState.PENDING_UPDATE)
                     recordFailure(op, "HTTP ${response.code()}")
                     return false
                 }
-                taskDao.setState(id, LocalState.SYNCED)
+                val returnedTask = response.body()?.task
+                if (returnedTask?.nextDueDate != null) {
+                    taskDao.upsert(returnedTask.toEntity())
+                    taskDao.replaceLabels(id, returnedTask.labels.map { it.id })
+                } else {
+                    taskDao.deleteById(id)
+                }
                 outboxDao.deleteById(op.id)
             }
             OutboxOpType.DUE_DATE -> {

--- a/android/app/src/main/java/com/dkhalife/tasks/repo/TaskRepository.kt
+++ b/android/app/src/main/java/com/dkhalife/tasks/repo/TaskRepository.kt
@@ -252,7 +252,7 @@ class TaskRepository @Inject constructor(
         return try {
             db.withTransaction {
                 val existing = taskDao.getTaskById(id)?.task
-                val resolvedState = if (existing?.localState == LocalState.PENDING_CREATE) {
+                val resolvedState = if (existing?.localState == LocalState.PENDING_CREATE && localState == LocalState.PENDING_UPDATE) {
                     LocalState.PENDING_CREATE
                 } else {
                     localState

--- a/android/app/src/main/java/com/dkhalife/tasks/repo/TaskRepository.kt
+++ b/android/app/src/main/java/com/dkhalife/tasks/repo/TaskRepository.kt
@@ -31,11 +31,6 @@ import java.util.UUID
 import javax.inject.Inject
 import javax.inject.Singleton
 
-data class TaskWithSyncState(
-    val task: Task,
-    val pendingSync: Boolean,
-)
-
 @Singleton
 class TaskRepository @Inject constructor(
     private val api: TaskWizardApi,
@@ -48,17 +43,6 @@ class TaskRepository @Inject constructor(
     private val telemetryManager: TelemetryManager,
 ) {
     private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
-
-    val taskStates: StateFlow<List<TaskWithSyncState>> = taskDao.observeTasks()
-        .map { rows ->
-            rows.map { r ->
-                TaskWithSyncState(
-                    task = r.toDomain(),
-                    pendingSync = r.task.localState != LocalState.SYNCED,
-                )
-            }
-        }
-        .stateIn(scope, SharingStarted.Eagerly, emptyList())
 
     val tasks: StateFlow<List<Task>> = taskDao.observeTasks()
         .map { rows -> rows.map { it.toDomain() } }
@@ -235,13 +219,13 @@ class TaskRepository @Inject constructor(
     }
 
     suspend fun completeTask(id: Int, endRecurrence: Boolean = false): Result<Unit> =
-        enqueueTaskOp(id, OutboxOpType.COMPLETE, endRecurrence.toString())
+        enqueueTaskOp(id, OutboxOpType.COMPLETE, endRecurrence.toString(), LocalState.PENDING_COMPLETE)
 
     suspend fun uncompleteTask(id: Int): Result<Unit> =
         enqueueTaskOp(id, OutboxOpType.UNCOMPLETE, null)
 
     suspend fun skipTask(id: Int): Result<Unit> =
-        enqueueTaskOp(id, OutboxOpType.SKIP, null)
+        enqueueTaskOp(id, OutboxOpType.SKIP, null, LocalState.PENDING_SKIP)
 
     suspend fun updateDueDate(id: Int, dueDate: String): Result<Unit> {
         return try {
@@ -264,10 +248,16 @@ class TaskRepository @Inject constructor(
         }
     }
 
-    private suspend fun enqueueTaskOp(id: Int, opType: String, payload: String?): Result<Unit> {
+    private suspend fun enqueueTaskOp(id: Int, opType: String, payload: String?, localState: String = LocalState.PENDING_UPDATE): Result<Unit> {
         return try {
             db.withTransaction {
-                taskDao.setState(id, LocalState.PENDING_UPDATE)
+                val existing = taskDao.getTaskById(id)?.task
+                val resolvedState = if (existing?.localState == LocalState.PENDING_CREATE) {
+                    LocalState.PENDING_CREATE
+                } else {
+                    localState
+                }
+                taskDao.setState(id, resolvedState)
                 outboxDao.insert(
                     OutboxEntity(
                         entityType = OutboxEntityType.TASK,

--- a/android/app/src/main/java/com/dkhalife/tasks/viewmodel/TaskListViewModel.kt
+++ b/android/app/src/main/java/com/dkhalife/tasks/viewmodel/TaskListViewModel.kt
@@ -6,7 +6,6 @@ import com.dkhalife.tasks.data.GroupingRepository
 import com.dkhalife.tasks.data.TaskGroup
 import com.dkhalife.tasks.data.TaskGrouper
 import com.dkhalife.tasks.data.TaskGrouping
-import com.dkhalife.tasks.data.db.LocalState
 import com.dkhalife.tasks.data.db.dao.OutboxDao
 import com.dkhalife.tasks.data.network.NetworkMonitor
 import com.dkhalife.tasks.model.Label
@@ -24,7 +23,6 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flowOn
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -48,10 +46,6 @@ class TaskListViewModel @Inject constructor(
 
     val pendingSyncCount: StateFlow<Int> = outboxDao.observeCount()
         .stateIn(viewModelScope, SharingStarted.Eagerly, 0)
-
-    val pendingSyncTaskIds: StateFlow<Set<Int>> = taskRepository.taskStates
-        .map { list -> list.filter { it.pendingSync }.map { it.task.id }.toSet() }
-        .stateIn(viewModelScope, SharingStarted.Eagerly, emptySet())
 
     private val _isRefreshing = MutableStateFlow(false)
     val isRefreshing: StateFlow<Boolean> = _isRefreshing


### PR DESCRIPTION
## Summary

Tasks now disappear from the active list immediately when completed or skipped, instead of waiting for server sync.

## Changes

- **LocalState.kt** — Added PENDING_COMPLETE and PENDING_SKIP local states
- **TaskDao.kt** — observeTasks() filters out PENDING_COMPLETE/PENDING_SKIP; remapId() preserves non-PENDING_CREATE states
- **TaskRepository.kt** — enqueueTaskOp() accepts operation-specific localState; removed unused TaskWithSyncState/taskStates
- **TaskWizardApi.kt** — completeTask/skipTask/uncompleteTask return Response<TaskResponse> (matching actual server response)
- **SyncCoordinator.kt** — On success: upserts returned task if recurring, deletes if not. On failure: reverts state so task reappears
- **TaskListViewModel.kt** — Removed unused pendingSyncTaskIds and dead imports

## Edge Cases Handled

- **Failed sync**: Task reappears in active list (reverted to PENDING_UPDATE), outbox retries on next sync
- **Offline**: Task hidden immediately; processes when connectivity returns
- **Create-then-complete before sync**: PENDING_CREATE preserved so CREATE processes first; remapId() preserves PENDING_COMPLETE state
- **Recurring tasks**: Server returns updated task with new nextDueDate; upserted as SYNCED — no flicker
