### PR TITLE
Simplify web auth: remove ssoSilent, add server-side sessions

### DIFF
--- a/apiserver/config/config.go
+++ b/apiserver/config/config.go
@@ -45,6 +45,7 @@ type ServerConfig struct {
 	LogLevel             string        `mapstructure:"log_level" yaml:"log_level"`
 	AllowedOrigins       []string      `mapstructure:"allowed_origins" yaml:"allowed_origins"`
 	AllowCorsCredentials bool          `mapstructure:"allow_cors_credentials" yaml:"allow_cors_credentials"`
+	SessionDuration      time.Duration `mapstructure:"session_duration" yaml:"session_duration" default:"720h"`
 }
 
 type SchedulerConfig struct {
@@ -76,6 +77,7 @@ func LoadConfig(configFile string) *Config {
 	_ = viper.BindEnv("entra.client_id", "TW_ENTRA_CLIENT_ID")
 	_ = viper.BindEnv("entra.audience", "TW_ENTRA_AUDIENCE")
 	_ = viper.BindEnv("entra.issuer", "TW_ENTRA_ISSUER")
+	_ = viper.BindEnv("server.session_duration", "TW_SESSION_DURATION")
 	_ = viper.BindEnv("database.type", "TW_DATABASE_TYPE")
 	_ = viper.BindEnv("database.host", "TW_DATABASE_HOST")
 	_ = viper.BindEnv("database.port", "TW_DATABASE_PORT")

--- a/apiserver/internal/apis/user.go
+++ b/apiserver/internal/apis/user.go
@@ -2,11 +2,13 @@ package apis
 
 import (
 	"net/http"
+	"time"
 
 	"dkhalife.com/tasks/core/config"
 	authMW "dkhalife.com/tasks/core/internal/middleware/auth"
 	"dkhalife.com/tasks/core/internal/models"
 	nRepo "dkhalife.com/tasks/core/internal/repos/notifier"
+	sRepo "dkhalife.com/tasks/core/internal/repos/session"
 	uRepo "dkhalife.com/tasks/core/internal/repos/user"
 	"dkhalife.com/tasks/core/internal/services/logging"
 	"dkhalife.com/tasks/core/internal/services/users"
@@ -19,14 +21,16 @@ import (
 
 type UsersAPIHandler struct {
 	userRepo    uRepo.IUserRepo
+	sessionRepo sRepo.ISessionRepo
 	userService *users.UserService
 	nRepo       *nRepo.NotificationRepository
 	cfg         *config.Config
 }
 
-func UsersAPI(ur uRepo.IUserRepo, nRepo *nRepo.NotificationRepository, us *users.UserService, cfg *config.Config) *UsersAPIHandler {
+func UsersAPI(ur uRepo.IUserRepo, sr sRepo.ISessionRepo, nRepo *nRepo.NotificationRepository, us *users.UserService, cfg *config.Config) *UsersAPIHandler {
 	return &UsersAPIHandler{
 		userRepo:    ur,
+		sessionRepo: sr,
 		userService: us,
 		nRepo:       nRepo,
 		cfg:         cfg,
@@ -109,6 +113,41 @@ func (h *UsersAPIHandler) CancelDeletion(c *gin.Context) {
 	c.JSON(status, response)
 }
 
+func (h *UsersAPIHandler) CreateSession(c *gin.Context) {
+	currentIdentity := auth.CurrentIdentity(c)
+	log := logging.FromContext(c)
+
+	duration := h.cfg.Server.SessionDuration
+	if duration == 0 {
+		duration = 30 * 24 * time.Hour
+	}
+
+	rawToken, err := h.sessionRepo.CreateSession(c, currentIdentity.UserID, duration)
+	if err != nil {
+		log.Errorf("failed to create session: %s", err.Error())
+		telemetry.TrackError(c, "session_create_failed", "user-handler", err, nil)
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error": "Failed to create session",
+		})
+		return
+	}
+
+	c.SetSameSite(http.SameSiteLaxMode)
+	c.SetCookie(authMW.SessionCookieName, rawToken, int(duration.Seconds()), "/", "", false, true)
+	c.Status(http.StatusCreated)
+}
+
+func (h *UsersAPIHandler) DeleteCurrentSession(c *gin.Context) {
+	sessionToken, err := c.Cookie(authMW.SessionCookieName)
+	if err == nil && sessionToken != "" {
+		_ = h.sessionRepo.DeleteSession(c, sessionToken)
+	}
+
+	c.SetSameSite(http.SameSiteLaxMode)
+	c.SetCookie(authMW.SessionCookieName, "", -1, "/", "", false, true)
+	c.Status(http.StatusNoContent)
+}
+
 func UserRoutes(router *gin.Engine, h *UsersAPIHandler, authMiddleware *authMW.AuthMiddleware, limiter *limiter.Limiter) {
 	userRoutes := router.Group("api/v1/users")
 	userRoutes.Use(authMiddleware.MiddlewareFunc(), middleware.RateLimitMiddleware(limiter))
@@ -123,5 +162,7 @@ func UserRoutes(router *gin.Engine, h *UsersAPIHandler, authMiddleware *authMW.A
 	authRoutes.Use(middleware.RateLimitMiddleware(limiter))
 	{
 		authRoutes.GET("/config", h.GetAuthConfig)
+		authRoutes.POST("/session", authMiddleware.MiddlewareFunc(), h.CreateSession)
+		authRoutes.DELETE("/session", authMiddleware.MiddlewareFunc(), h.DeleteCurrentSession)
 	}
 }

--- a/apiserver/internal/apis/user.go
+++ b/apiserver/internal/apis/user.go
@@ -132,8 +132,9 @@ func (h *UsersAPIHandler) CreateSession(c *gin.Context) {
 		return
 	}
 
+	secure := h.cfg.Server.HostName != ""
 	c.SetSameSite(http.SameSiteLaxMode)
-	c.SetCookie(authMW.SessionCookieName, rawToken, int(duration.Seconds()), "/", "", false, true)
+	c.SetCookie(authMW.SessionCookieName, rawToken, int(duration.Seconds()), "/", "", secure, true)
 	c.Status(http.StatusCreated)
 }
 
@@ -143,8 +144,9 @@ func (h *UsersAPIHandler) DeleteCurrentSession(c *gin.Context) {
 		_ = h.sessionRepo.DeleteSession(c, sessionToken)
 	}
 
+	secure := h.cfg.Server.HostName != ""
 	c.SetSameSite(http.SameSiteLaxMode)
-	c.SetCookie(authMW.SessionCookieName, "", -1, "/", "", false, true)
+	c.SetCookie(authMW.SessionCookieName, "", -1, "/", "", secure, true)
 	c.Status(http.StatusNoContent)
 }
 

--- a/apiserver/internal/middleware/auth/auth.go
+++ b/apiserver/internal/middleware/auth/auth.go
@@ -11,6 +11,7 @@ import (
 
 	"dkhalife.com/tasks/core/config"
 	"dkhalife.com/tasks/core/internal/models"
+	sRepo "dkhalife.com/tasks/core/internal/repos/session"
 	uRepo "dkhalife.com/tasks/core/internal/repos/user"
 	"dkhalife.com/tasks/core/internal/telemetry"
 	authUtils "dkhalife.com/tasks/core/internal/utils/auth"
@@ -18,14 +19,17 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
+const SessionCookieName = "tw_session"
+
 type AuthMiddleware struct {
-	enabled  bool
-	keySet   oidc.KeySet
-	issuer   string
-	audience string
-	tenantID string
-	clientID string
-	userRepo uRepo.IUserRepo
+	enabled     bool
+	keySet      oidc.KeySet
+	issuer      string
+	audience    string
+	tenantID    string
+	clientID    string
+	userRepo    uRepo.IUserRepo
+	sessionRepo sRepo.ISessionRepo
 }
 
 type accessTokenClaims struct {
@@ -36,10 +40,11 @@ type accessTokenClaims struct {
 	ObjectID  string `json:"oid"`
 }
 
-func NewAuthMiddleware(cfg *config.Config, userRepo uRepo.IUserRepo) (*AuthMiddleware, error) {
+func NewAuthMiddleware(cfg *config.Config, userRepo uRepo.IUserRepo, sessionRepo sRepo.ISessionRepo) (*AuthMiddleware, error) {
 	m := &AuthMiddleware{
-		enabled:  cfg.Entra.Enabled,
-		userRepo: userRepo,
+		enabled:     cfg.Entra.Enabled,
+		userRepo:    userRepo,
+		sessionRepo: sessionRepo,
 	}
 
 	if !cfg.Entra.Enabled {
@@ -93,12 +98,21 @@ func (m *AuthMiddleware) authenticate(c *gin.Context) (*models.SignedInIdentity,
 		return m.bypassAuth(c.Request.Context())
 	}
 
+	// Prefer bearer token when present (explicit auth takes precedence)
 	token := extractBearerToken(c)
-	if token == "" {
-		return nil, fmt.Errorf("missing authorization token")
+	if token != "" {
+		return m.verifyAccessToken(c.Request.Context(), token)
 	}
 
-	return m.verifyAccessToken(c.Request.Context(), token)
+	// Fall back to session cookie
+	if sessionToken, err := c.Cookie(SessionCookieName); err == nil && sessionToken != "" {
+		identity, err := m.authenticateSession(c.Request.Context(), sessionToken)
+		if err == nil {
+			return identity, nil
+		}
+	}
+
+	return nil, fmt.Errorf("missing authorization token")
 }
 
 func extractBearerToken(c *gin.Context) string {
@@ -124,7 +138,7 @@ func (m *AuthMiddleware) verifyAccessToken(ctx context.Context, rawToken string)
 		return nil, fmt.Errorf("invalid token issuer")
 	}
 
-	if claims.Audience != m.audience {
+	if claims.Audience != m.audience && claims.Audience != m.clientID {
 		return nil, fmt.Errorf("invalid token audience")
 	}
 
@@ -139,6 +153,29 @@ func (m *AuthMiddleware) verifyAccessToken(ctx context.Context, rawToken string)
 	user, err := m.userRepo.EnsureUser(ctx, claims.TenantID, claims.ObjectID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to resolve user identity: %s", err.Error())
+	}
+
+	return &models.SignedInIdentity{
+		UserID:          user.ID,
+		Type:            models.IdentityTypeUser,
+		Scopes:          models.AllUserScopes(),
+		PendingDeletion: user.DeletionRequestedAt != nil,
+	}, nil
+}
+
+func (m *AuthMiddleware) authenticateSession(ctx context.Context, rawToken string) (*models.SignedInIdentity, error) {
+	session, err := m.sessionRepo.ValidateSession(ctx, rawToken)
+	if err != nil {
+		return nil, fmt.Errorf("invalid session: %s", err.Error())
+	}
+
+	user, err := m.userRepo.GetUser(ctx, session.UserID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve session user: %s", err.Error())
+	}
+
+	if user.Disabled {
+		return nil, fmt.Errorf("account is disabled")
 	}
 
 	return &models.SignedInIdentity{

--- a/apiserver/internal/migrations/007_sessions.go
+++ b/apiserver/internal/migrations/007_sessions.go
@@ -1,0 +1,68 @@
+package migrations
+
+import (
+	"context"
+	"fmt"
+
+	"gorm.io/gorm"
+)
+
+func init() {
+	Register(&SessionsMigration{})
+}
+
+type SessionsMigration struct{}
+
+func (m *SessionsMigration) Version() int {
+	return 7
+}
+
+func (m *SessionsMigration) Name() string {
+	return "sessions"
+}
+
+func (m *SessionsMigration) Up(ctx context.Context, db *gorm.DB) error {
+	dbCtx := db.WithContext(ctx)
+	dialect := db.Dialector.Name()
+
+	switch dialect {
+	case "sqlite":
+		stmts := []string{
+			`CREATE TABLE sessions (
+				id INTEGER PRIMARY KEY AUTOINCREMENT,
+				user_id INTEGER NOT NULL,
+				token_hash TEXT NOT NULL,
+				expires_at DATETIME NOT NULL,
+				created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+				FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+			)`,
+			`CREATE UNIQUE INDEX idx_sessions_token_hash ON sessions(token_hash)`,
+			`CREATE INDEX idx_sessions_user_id ON sessions(user_id)`,
+			`CREATE INDEX idx_sessions_expires_at ON sessions(expires_at)`,
+		}
+		for _, stmt := range stmts {
+			if err := dbCtx.Exec(stmt).Error; err != nil {
+				return err
+			}
+		}
+		return nil
+	case "mysql":
+		return dbCtx.Exec(`CREATE TABLE sessions (
+			id INT AUTO_INCREMENT PRIMARY KEY,
+			user_id INT NOT NULL,
+			token_hash VARCHAR(64) NOT NULL,
+			expires_at DATETIME NOT NULL,
+			created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+			UNIQUE INDEX idx_sessions_token_hash (token_hash),
+			INDEX idx_sessions_user_id (user_id),
+			INDEX idx_sessions_expires_at (expires_at),
+			FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+		)`).Error
+	default:
+		return fmt.Errorf("unsupported dialect: %s", dialect)
+	}
+}
+
+func (m *SessionsMigration) Down(ctx context.Context, db *gorm.DB) error {
+	return db.WithContext(ctx).Exec("DROP TABLE IF EXISTS sessions").Error
+}

--- a/apiserver/internal/models/session.go
+++ b/apiserver/internal/models/session.go
@@ -1,0 +1,11 @@
+package models
+
+import "time"
+
+type Session struct {
+	ID        int       `gorm:"primary_key;autoIncrement"`
+	UserID    int       `gorm:"not null;index"`
+	TokenHash string    `gorm:"column:token_hash;size:64;not null;uniqueIndex"`
+	ExpiresAt time.Time `gorm:"not null;index"`
+	CreatedAt time.Time `gorm:"default:CURRENT_TIMESTAMP"`
+}

--- a/apiserver/internal/repos/notifier/notifier.go
+++ b/apiserver/internal/repos/notifier/notifier.go
@@ -2,6 +2,7 @@ package notifier
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -21,6 +22,9 @@ func NewNotificationRepository(db *gorm.DB) *NotificationRepository {
 func (r *NotificationRepository) GetUserNotificationSettings(c context.Context, userID int) (*models.NotificationSettings, error) {
 	var settings models.NotificationSettings
 	if err := r.db.WithContext(c).Model(&models.NotificationSettings{}).First(&settings, userID).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return &models.NotificationSettings{UserID: userID}, nil
+		}
 		return nil, err
 	}
 	return &settings, nil

--- a/apiserver/internal/repos/session/session.go
+++ b/apiserver/internal/repos/session/session.go
@@ -1,0 +1,92 @@
+package repos
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"time"
+
+	"dkhalife.com/tasks/core/internal/models"
+	"gorm.io/gorm"
+)
+
+type ISessionRepo interface {
+	CreateSession(ctx context.Context, userID int, duration time.Duration) (string, error)
+	ValidateSession(ctx context.Context, rawToken string) (*models.Session, error)
+	DeleteSession(ctx context.Context, rawToken string) error
+	DeleteUserSessions(ctx context.Context, userID int) error
+	CleanupExpired(ctx context.Context) error
+}
+
+type SessionRepository struct {
+	db *gorm.DB
+}
+
+var _ ISessionRepo = (*SessionRepository)(nil)
+
+func NewSessionRepository(db *gorm.DB) ISessionRepo {
+	return &SessionRepository{db: db}
+}
+
+func generateToken() (string, error) {
+	bytes := make([]byte, 32)
+	if _, err := rand.Read(bytes); err != nil {
+		return "", fmt.Errorf("generate session token: %s", err.Error())
+	}
+	return hex.EncodeToString(bytes), nil
+}
+
+func hashToken(rawToken string) string {
+	h := sha256.Sum256([]byte(rawToken))
+	return hex.EncodeToString(h[:])
+}
+
+func (r *SessionRepository) CreateSession(ctx context.Context, userID int, duration time.Duration) (string, error) {
+	rawToken, err := generateToken()
+	if err != nil {
+		return "", err
+	}
+
+	session := &models.Session{
+		UserID:    userID,
+		TokenHash: hashToken(rawToken),
+		ExpiresAt: time.Now().UTC().Add(duration),
+	}
+
+	if err := r.db.WithContext(ctx).Create(session).Error; err != nil {
+		return "", fmt.Errorf("create session: %s", err.Error())
+	}
+
+	return rawToken, nil
+}
+
+func (r *SessionRepository) ValidateSession(ctx context.Context, rawToken string) (*models.Session, error) {
+	var session models.Session
+	tokenHash := hashToken(rawToken)
+
+	if err := r.db.WithContext(ctx).Where("token_hash = ?", tokenHash).First(&session).Error; err != nil {
+		return nil, fmt.Errorf("session not found: %s", err.Error())
+	}
+
+	if time.Now().UTC().After(session.ExpiresAt) {
+		_ = r.db.WithContext(ctx).Delete(&session)
+		return nil, fmt.Errorf("session has expired")
+	}
+
+	return &session, nil
+}
+
+func (r *SessionRepository) DeleteSession(ctx context.Context, rawToken string) error {
+	tokenHash := hashToken(rawToken)
+	return r.db.WithContext(ctx).Where("token_hash = ?", tokenHash).Delete(&models.Session{}).Error
+}
+
+func (r *SessionRepository) DeleteUserSessions(ctx context.Context, userID int) error {
+	return r.db.WithContext(ctx).Where("user_id = ?", userID).Delete(&models.Session{}).Error
+}
+
+func (r *SessionRepository) CleanupExpired(ctx context.Context) error {
+	return r.db.WithContext(ctx).Where("expires_at < ?", time.Now().UTC()).Delete(&models.Session{}).Error
+}

--- a/apiserver/internal/services/scheduler/scheduler.go
+++ b/apiserver/internal/services/scheduler/scheduler.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"dkhalife.com/tasks/core/config"
+	sRepo "dkhalife.com/tasks/core/internal/repos/session"
 	"dkhalife.com/tasks/core/internal/services/logging"
 	"dkhalife.com/tasks/core/internal/services/notifications"
 	"dkhalife.com/tasks/core/internal/services/users"
@@ -15,14 +16,16 @@ type Scheduler struct {
 	stopChan    chan bool
 	notifier    *notifications.Notifier
 	userService *users.UserService
+	sessionRepo sRepo.ISessionRepo
 	config      config.SchedulerConfig
 }
 
-func NewScheduler(cfg *config.Config, n *notifications.Notifier, us *users.UserService) *Scheduler {
+func NewScheduler(cfg *config.Config, n *notifications.Notifier, us *users.UserService, sr sRepo.ISessionRepo) *Scheduler {
 	return &Scheduler{
 		stopChan:    make(chan bool),
 		notifier:    n,
 		userService: us,
+		sessionRepo: sr,
 		config:      cfg.SchedulerJobs,
 	}
 }
@@ -35,6 +38,7 @@ func (s *Scheduler) Start(c context.Context) {
 	go s.runScheduler(c, "NOTIFICATION_SENDER", s.notifier.LoadAndSendNotificationJob, s.config.DueFrequency)
 	go s.runScheduler(c, "NOTIFICATION_CLEANUP", s.notifier.CleanupNotifications, s.config.NotificationCleanup)
 	go s.runScheduler(c, "ACCOUNT_DELETION", s.userService.ProcessDeletions, s.config.AccountDeletionFrequency)
+	go s.runScheduler(c, "SESSION_CLEANUP", s.sessionRepo.CleanupExpired, 1*time.Hour)
 }
 
 func (s *Scheduler) runScheduler(c context.Context, jobName string, job func(c context.Context) error, interval time.Duration) {

--- a/apiserver/internal/services/users/user_test.go
+++ b/apiserver/internal/services/users/user_test.go
@@ -36,7 +36,7 @@ func (s *UserServiceTestSuite) SetupTest() {
 	}
 	s.repo = uRepo.NewUserRepository(s.DB, cfg)
 
-	authMiddleware, _ := authMW.NewAuthMiddleware(&config.Config{}, s.repo)
+	authMiddleware, _ := authMW.NewAuthMiddleware(&config.Config{}, s.repo, nil)
 	taskRepo := tRepo.NewTaskRepository(s.DB, cfg)
 	labelRepo := lRepo.NewLabelRepository(s.DB, cfg)
 	s.wsServer = ws.NewWSServer(authMiddleware, taskRepo, labelRepo, s.repo)

--- a/apiserver/internal/utils/middleware/middleware.go
+++ b/apiserver/internal/utils/middleware/middleware.go
@@ -71,7 +71,7 @@ func SecurityHeaders(cfg *config.Config) gin.HandlerFunc {
 
 	return func(c *gin.Context) {
 		scheme := effectiveScheme(c)
-		if scheme == "http" {
+		if scheme == "http" && hostName != "" {
 			target := fmt.Sprintf("https://%s", hostName)
 			if port != 443 {
 				target = fmt.Sprintf("%s:%d", target, port)

--- a/apiserver/internal/ws/server_test.go
+++ b/apiserver/internal/ws/server_test.go
@@ -50,7 +50,7 @@ func (s *WSServerTestSuite) SetupTest() {
 	}
 
 	mockRepo := &mockWSUserRepo{}
-	authMiddleware, err := authMW.NewAuthMiddleware(cfg, mockRepo)
+	authMiddleware, err := authMW.NewAuthMiddleware(cfg, mockRepo, nil)
 	s.Require().NoError(err)
 
 	s.server = NewWSServer(authMiddleware, nil, nil, mockRepo)

--- a/apiserver/main.go
+++ b/apiserver/main.go
@@ -27,6 +27,7 @@ import (
 	apis "dkhalife.com/tasks/core/internal/apis"
 	lRepo "dkhalife.com/tasks/core/internal/repos/label"
 	nRepo "dkhalife.com/tasks/core/internal/repos/notifier"
+	sRepo "dkhalife.com/tasks/core/internal/repos/session"
 	tRepo "dkhalife.com/tasks/core/internal/repos/task"
 	uRepo "dkhalife.com/tasks/core/internal/repos/user"
 	lService "dkhalife.com/tasks/core/internal/services/labels"
@@ -66,6 +67,7 @@ func main() {
 		fx.Provide(tRepo.NewTaskRepository),
 		fx.Provide(apis.TasksAPI),
 		fx.Provide(uRepo.NewUserRepository),
+		fx.Provide(sRepo.NewSessionRepository),
 		fx.Provide(nRepo.NewNotificationRepository),
 		fx.Provide(apis.UsersAPI),
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,7 @@
 import { NavBar } from './views/Navigation/NavBar'
 import { Outlet, useLocation, useNavigate } from 'react-router-dom'
-import { hasCachedAccounts, initializeMsal, isAuthEnabled, loginSilently, loginWithRedirect } from './utils/msal'
+import { initializeMsal, isAuthEnabled, acquireAccessToken } from './utils/msal'
+import { CreateSession } from './api/auth'
 import { NavigationPaths } from './utils/navigation'
 import React from 'react'
 import { CssBaseline, CssVarsProvider } from '@mui/joy'
@@ -14,6 +15,7 @@ import { StatusList } from './components/StatusList'
 import { DeletionBanner } from './components/DeletionBanner'
 import { fetchTasks, initGroups } from './store/tasksSlice'
 import { FIVE_MINUTES_MS } from '@/constants/time'
+import { isRedirectingToLogin } from './utils/api'
 
 type AppProps = {
   pathname: string
@@ -25,9 +27,22 @@ type AppProps = {
   initGroups: () => void
 }
 
-class AppImpl extends React.Component<AppProps> {
+type AppState = {
+  ready: boolean
+}
+
+class AppImpl extends React.Component<AppProps, AppState> {
   private initializedAuthenticated = false
   private initializingAuthenticated = false
+
+  constructor(props: AppProps) {
+    super(props)
+    this.state = { ready: false }
+  }
+
+  private isPublicRoute = (): boolean => {
+    return this.props.pathname === NavigationPaths.Privacy || this.props.pathname === NavigationPaths.Login
+  }
 
   private onVisibilityChange = () => {
     if (!document.hidden && this.initializedAuthenticated) {
@@ -84,17 +99,29 @@ class AppImpl extends React.Component<AppProps> {
 
   async componentDidMount(): Promise<void> {
     await initializeMsal()
-    const silentOk = await loginSilently()
-    if (silentOk) {
-      await this.initializeAuthenticated()
-    } else if (isAuthEnabled() && this.props.pathname !== NavigationPaths.Privacy) {
-      if (await hasCachedAccounts()) {
-        await loginWithRedirect()
-      } else if (this.props.pathname !== NavigationPaths.Login) {
-        this.props.navigate(NavigationPaths.Login)
+
+    if (!this.isPublicRoute()) {
+      if (isAuthEnabled()) {
+        try {
+          const token = await acquireAccessToken()
+          if (token) {
+            try {
+              await CreateSession()
+            } catch {
+              // Session creation is best-effort
+            }
+          }
+        } catch {
+          // No MSAL tokens; will rely on session cookie
+        }
       }
+
+      await this.initializeAuthenticated()
     }
 
+    if (!isRedirectingToLogin()) {
+      this.setState({ ready: true })
+    }
     document.addEventListener('visibilitychange', this.onVisibilityChange)
   }
 
@@ -117,6 +144,11 @@ class AppImpl extends React.Component<AppProps> {
 
   render() {
     const { pathname } = this.props
+    const { ready } = this.state
+
+    if (!ready && !this.isPublicRoute()) {
+      return null
+    }
 
     return (
       <div style={{ minHeight: '100vh' }}>

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -1,3 +1,5 @@
+import { acquireAccessToken } from '@/utils/msal'
+
 export interface AuthConfig {
   enabled: boolean
   tenant_id: string
@@ -7,6 +9,35 @@ export interface AuthConfig {
 
 export const GetAuthConfig = async () => {
   const API_URL = import.meta.env.VITE_APP_API_URL
-  const response = await fetch(`${API_URL}/api/v1/auth/config`)
+  const response = await fetch(`${API_URL}/api/v1/auth/config`, { credentials: 'include' })
   return (await response.json()) as AuthConfig
+}
+
+export const CreateSession = async () => {
+  const API_URL = import.meta.env.VITE_APP_API_URL
+  const headers: HeadersInit = { 'Content-Type': 'application/json' }
+
+  try {
+    const token = await acquireAccessToken()
+    if (token) {
+      headers['Authorization'] = 'Bearer ' + token
+    }
+  } catch {
+    return
+  }
+
+  const response = await fetch(`${API_URL}/api/v1/auth/session`, {
+    method: 'POST',
+    headers,
+    credentials: 'include',
+  })
+
+  if (!response.ok) {
+    throw new Error('Failed to create session')
+  }
+}
+
+export const DeleteSession = async () => {
+  const API_URL = import.meta.env.VITE_APP_API_URL
+  await fetch(`${API_URL}/api/v1/auth/session`, { method: 'DELETE', credentials: 'include' })
 }

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -11,6 +11,8 @@ type FailureResponse = {
 
 let redirectingToLogin = false
 
+export const isRedirectingToLogin = () => redirectingToLogin
+
 export async function Request<SuccessfulResponse>(
   url: string,
   method: RequestMethod = 'GET',
@@ -27,13 +29,11 @@ export async function Request<SuccessfulResponse>(
   if (requiresAuth && isAuthEnabled()) {
     try {
       const token = await acquireAccessToken()
-      headers['Authorization'] = 'Bearer ' + token
-    } catch {
-      if (!redirectingToLogin) {
-        redirectingToLogin = true
-        window.location.href = NavigationPaths.Login
+      if (token) {
+        headers['Authorization'] = 'Bearer ' + token
       }
-      throw new Error('Authentication required')
+    } catch {
+      // MSAL token not available; server session cookie will provide authentication
     }
   }
 
@@ -41,6 +41,7 @@ export async function Request<SuccessfulResponse>(
     method,
     headers,
     cache: 'no-store',
+    credentials: 'include',
   }
 
   if (method !== 'GET') {
@@ -48,6 +49,16 @@ export async function Request<SuccessfulResponse>(
   }
 
   const response: Response = await fetch(fullURL, options)
+
+  if (response.status === 401) {
+    if (!redirectingToLogin) {
+      redirectingToLogin = true
+      const returnTo = encodeURIComponent(window.location.pathname)
+      window.location.href = `${NavigationPaths.Login}?return_to=${returnTo}`
+    }
+    throw new Error('Authentication required')
+  }
+
   const HTTP_STATUS_NO_CONTENT = 204
   if (response.status === HTTP_STATUS_NO_CONTENT) {
     return {} as SuccessfulResponse

--- a/frontend/src/utils/msal.ts
+++ b/frontend/src/utils/msal.ts
@@ -83,50 +83,7 @@ export const isAuthEnabled = (): boolean => {
 export const loginWithRedirect = async () => {
   if (!authConfig?.enabled || !pcaPromise) return
   const pca = await pcaPromise
-  await pca.loginRedirect({ scopes: getScopes() })
-}
-
-export const hasCachedAccounts = async (): Promise<boolean> => {
-  if (!authConfig?.enabled || !pcaPromise) return false
-  const pca = await pcaPromise
-  return pca.getAllAccounts().some(a => a.tenantId === authConfig?.tenant_id)
-}
-
-const AUTH_COOKIE = 'tw_auth'
-
-const setAuthCookie = () => {
-  document.cookie = `${AUTH_COOKIE}=1; path=/; SameSite=Strict; max-age=31536000`
-}
-
-const clearAuthCookie = () => {
-  document.cookie = `${AUTH_COOKIE}=; path=/; SameSite=Strict; max-age=0`
-}
-
-export const loginSilently = async (): Promise<boolean> => {
-  if (!authConfig?.enabled || !pcaPromise) return true
-  const pca = await pcaPromise
-  try {
-    const account = ensureActiveAccount(pca)
-    cachedAuthResult = await pca.acquireTokenSilent({ scopes: getScopes(), account })
-    setAuthCookie()
-    return true
-  } catch {
-    try {
-      const account = pca.getActiveAccount() ?? pca.getAllAccounts().find(a => a.tenantId === authConfig?.tenant_id)
-      cachedAuthResult = await pca.ssoSilent({
-        scopes: getScopes(),
-        loginHint: account?.username,
-      })
-      if (cachedAuthResult.account) {
-        pca.setActiveAccount(cachedAuthResult.account)
-      }
-      setAuthCookie()
-      return true
-    } catch {
-      clearAuthCookie()
-      return false
-    }
-  }
+  await pca.loginRedirect({ scopes: getScopes(), prompt: 'select_account' })
 }
 
 export const acquireAccessToken = async (): Promise<string> => {
@@ -142,7 +99,6 @@ export const acquireAccessToken = async (): Promise<string> => {
 }
 
 export const logout = async () => {
-  clearAuthCookie()
   if (!authConfig?.enabled || !pcaPromise) {
     window.location.href = '/'
     return

--- a/frontend/src/views/Authorization/LoginView.tsx
+++ b/frontend/src/views/Authorization/LoginView.tsx
@@ -1,4 +1,3 @@
-import { Loading } from '@/Loading'
 import { Logo } from '@/Logo'
 import { Sheet } from '@mui/joy'
 import {
@@ -9,7 +8,8 @@ import {
 } from '@mui/joy'
 import React from 'react'
 import { Link } from 'react-router-dom'
-import { hasCachedAccounts, initializeMsal, loginSilently, loginWithRedirect } from '@/utils/msal'
+import { initializeMsal, isAuthEnabled, loginWithRedirect, acquireAccessToken } from '@/utils/msal'
+import { CreateSession } from '@/api/auth'
 import { setTitle } from '@/utils/dom'
 import { getQuery, NavigationPaths, WithNavigate } from '@/utils/navigation'
 import { connect } from 'react-redux'
@@ -22,13 +22,13 @@ type LoginViewProps = WithNavigate & {
 }
 
 type LoginViewState = {
-  authReady: boolean
+  msalReady: boolean
 }
 
 class LoginViewImpl extends React.Component<LoginViewProps, LoginViewState> {
   constructor(props: LoginViewProps) {
     super(props)
-    this.state = { authReady: false }
+    this.state = { msalReady: false }
   }
 
   private getReturnPath = (): string => {
@@ -38,21 +38,26 @@ class LoginViewImpl extends React.Component<LoginViewProps, LoginViewState> {
 
   async componentDidMount(): Promise<void> {
     setTitle('Login')
+
     await initializeMsal()
-    const silentOk = await loginSilently()
-    if (silentOk) {
-      this.props.navigate(this.getReturnPath())
-      return
-    }
-    try {
-      if (await hasCachedAccounts()) {
-        await loginWithRedirect()
-        return
+    this.setState({ msalReady: true })
+
+    if (isAuthEnabled()) {
+      try {
+        const token = await acquireAccessToken()
+        if (token) {
+          try {
+            await CreateSession()
+          } catch {
+            // Session creation is best-effort
+          }
+          this.props.navigate(this.getReturnPath())
+          return
+        }
+      } catch {
+        // No cached MSAL tokens; show sign-in button
       }
-    } catch (error) {
-      this.props.pushStatus((error as Error).message, 'error', 5000)
     }
-    this.setState({ authReady: true })
   }
 
   private handleLogin = async () => {
@@ -64,9 +69,7 @@ class LoginViewImpl extends React.Component<LoginViewProps, LoginViewState> {
   }
 
   render(): React.ReactNode {
-    if (!this.state.authReady) {
-      return <Loading />
-    }
+    const { msalReady } = this.state
 
     return (
       <Container
@@ -101,6 +104,8 @@ class LoginViewImpl extends React.Component<LoginViewProps, LoginViewState> {
               fullWidth
               size='lg'
               variant='solid'
+              disabled={!msalReady}
+              loading={!msalReady}
               sx={{
                 width: '100%',
                 mt: 3,

--- a/frontend/src/views/Navigation/NavBar.tsx
+++ b/frontend/src/views/Navigation/NavBar.tsx
@@ -53,6 +53,12 @@ export class NavBar extends React.Component<NavBarProps, NavBarState> {
   }
 
   private logout = async () => {
+    try {
+      const { DeleteSession } = await import('@/api/auth')
+      await DeleteSession()
+    } catch {
+      // Best effort
+    }
     const { logout } = await import('@/utils/msal')
     await logout()
   }

--- a/frontend/test/utils/msal.test.ts
+++ b/frontend/test/utils/msal.test.ts
@@ -27,14 +27,12 @@ describe('msal utils', () => {
     getAllAccounts: jest.Mock
     setActiveAccount: jest.Mock
     acquireTokenSilent: jest.Mock
-    ssoSilent: jest.Mock
     loginRedirect: jest.Mock
     logoutRedirect: jest.Mock
   }
 
   let initializeMsal: () => Promise<void>
-  let loginSilently: () => Promise<boolean>
-  let hasCachedAccounts: () => Promise<boolean>
+  let acquireAccessToken: () => Promise<string>
 
   beforeEach(async () => {
     jest.resetModules()
@@ -45,7 +43,6 @@ describe('msal utils', () => {
       getAllAccounts: jest.fn().mockReturnValue([]),
       setActiveAccount: jest.fn(),
       acquireTokenSilent: jest.fn(),
-      ssoSilent: jest.fn(),
       loginRedirect: jest.fn(),
       logoutRedirect: jest.fn(),
     }
@@ -65,64 +62,17 @@ describe('msal utils', () => {
 
     const module = await import('@/utils/msal')
     initializeMsal = module.initializeMsal
-    loginSilently = module.loginSilently
-    hasCachedAccounts = module.hasCachedAccounts
+    acquireAccessToken = module.acquireAccessToken
   })
 
-  describe('hasCachedAccounts', () => {
-    it('returns false when no accounts are cached', async () => {
-      await initializeMsal()
-      expect(await hasCachedAccounts()).toBe(false)
-    })
-
-    it('returns false when only accounts from other tenants are cached', async () => {
-      await initializeMsal()
-      mockPca.getAllAccounts.mockReturnValue([otherAccount])
-      expect(await hasCachedAccounts()).toBe(false)
-    })
-
-    it('returns true when a cached account matches the configured tenant', async () => {
-      await initializeMsal()
-      mockPca.getAllAccounts.mockReturnValue([tenantAccount])
-      expect(await hasCachedAccounts()).toBe(true)
-    })
-
-    it('returns true when mixed accounts include one for the configured tenant', async () => {
-      await initializeMsal()
-      mockPca.getAllAccounts.mockReturnValue([otherAccount, tenantAccount])
-      expect(await hasCachedAccounts()).toBe(true)
-    })
-  })
-
-  describe('loginSilently', () => {
-    it('returns true when acquireTokenSilent succeeds', async () => {
+  describe('acquireAccessToken', () => {
+    it('returns token when acquireTokenSilent succeeds', async () => {
       await initializeMsal()
       mockPca.getAllAccounts.mockReturnValue([tenantAccount])
       mockPca.acquireTokenSilent.mockResolvedValue(authResult)
 
-      expect(await loginSilently()).toBe(true)
-      expect(mockPca.ssoSilent).not.toHaveBeenCalled()
-    })
-
-    it('falls back to ssoSilent when acquireTokenSilent fails', async () => {
-      await initializeMsal()
-      mockPca.getAllAccounts.mockReturnValue([tenantAccount])
-      mockPca.acquireTokenSilent.mockRejectedValue(new Error('token expired'))
-      mockPca.ssoSilent.mockResolvedValue({ ...authResult })
-
-      expect(await loginSilently()).toBe(true)
-      expect(mockPca.ssoSilent).toHaveBeenCalledWith(
-        expect.objectContaining({ loginHint: tenantAccount.username }),
-      )
-    })
-
-    it('returns false when both acquireTokenSilent and ssoSilent fail', async () => {
-      await initializeMsal()
-      mockPca.getAllAccounts.mockReturnValue([tenantAccount])
-      mockPca.acquireTokenSilent.mockRejectedValue(new Error('token expired'))
-      mockPca.ssoSilent.mockRejectedValue(new Error('sso failed'))
-
-      expect(await loginSilently()).toBe(false)
+      const token = await acquireAccessToken()
+      expect(token).toBe('access-token')
     })
 
     it('selects the tenant-matching account when multiple accounts are cached', async () => {
@@ -130,18 +80,18 @@ describe('msal utils', () => {
       mockPca.getAllAccounts.mockReturnValue([otherAccount, tenantAccount])
       mockPca.acquireTokenSilent.mockResolvedValue(authResult)
 
-      await loginSilently()
+      await acquireAccessToken()
 
       expect(mockPca.setActiveAccount).toHaveBeenCalledWith(tenantAccount)
       expect(mockPca.setActiveAccount).not.toHaveBeenCalledWith(otherAccount)
     })
 
-    it('clears a wrong active account before throwing when no tenant account exists', async () => {
+    it('throws when no tenant account exists', async () => {
       await initializeMsal()
       mockPca.getActiveAccount.mockReturnValue(otherAccount)
       mockPca.getAllAccounts.mockReturnValue([otherAccount])
 
-      expect(await loginSilently()).toBe(false)
+      await expect(acquireAccessToken()).rejects.toThrow()
       expect(mockPca.setActiveAccount).toHaveBeenCalledWith(null)
     })
   })


### PR DESCRIPTION
## Summary

Redesigns the web authentication flow to eliminate slow, unreliable ssoSilent iframe-based auth and replace it with server-side sessions.

### Problems solved
- **Slow initial load**: Users waited 10+ seconds staring at a loading spinner before seeing the sign-in page due to ssoSilent iframe timeouts (third-party cookies blocked in modern browsers)
- **Overview page flash**: Unauthenticated users briefly saw the overview page before being redirected to login
- **No session persistence**: Users had to re-authenticate every browser session because MSAL SPA tokens expire after ~24h

### Changes

**Backend**
- Added server-side session model, repository, and migration (SHA-256 hashed tokens, 30-day expiry)
- Auth middleware: bearer token takes precedence, falls back to session cookie
- Accept both Application ID URI and client ID as token audience
- New endpoints: `POST /auth/session` (create), `DELETE /auth/session` (logout)
- Hourly session cleanup scheduler job
- Return default notification settings for new users (instead of 500)
- Skip HTTPS redirect when `host_name` is empty (dev mode)

**Frontend**
- Removed `loginSilently`, `ssoSilent`, and all iframe-based auth
- App renders nothing for protected routes until auth is confirmed (no flash)
- Login page shows sign-in button immediately with `prompt: 'select_account'`
- `CreateSession` uses raw fetch to avoid login redirect loops
- All API calls include `credentials: 'include'` for cookie transport