### PR TITLE
fix(migrations): use INTEGER for sessions.user_id to match users.id FK type

### DIFF
--- a/apiserver/internal/migrations/007_sessions.go
+++ b/apiserver/internal/migrations/007_sessions.go
@@ -47,15 +47,29 @@ func (m *SessionsMigration) Up(ctx context.Context, db *gorm.DB) error {
 		}
 		return nil
 	case "mysql":
+		// Detect the actual column type of users.id. Existing deployments may
+		// have users.id as BIGINT (e.g. created by an earlier GORM AutoMigrate)
+		// while fresh installs have INT. InnoDB requires the FK column type to
+		// match exactly, so derive sessions.user_id from users.id at runtime.
+		var userIDType string
+		row := dbCtx.Raw(`SELECT COLUMN_TYPE FROM information_schema.COLUMNS
+			WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'users' AND COLUMN_NAME = 'id'`).Row()
+		if err := row.Scan(&userIDType); err != nil {
+			return fmt.Errorf("failed to detect users.id column type: %s", err.Error())
+		}
+		if userIDType == "" {
+			return fmt.Errorf("users.id column type could not be determined")
+		}
+
 		stmts := []string{
-			`CREATE TABLE sessions (
-				id INTEGER PRIMARY KEY AUTO_INCREMENT,
-				user_id INTEGER NOT NULL,
+			fmt.Sprintf(`CREATE TABLE sessions (
+				id %s AUTO_INCREMENT PRIMARY KEY,
+				user_id %s NOT NULL,
 				token_hash VARCHAR(64) NOT NULL,
 				expires_at DATETIME NOT NULL,
 				created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
 				CONSTRAINT fk_users_sessions FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
-			)`,
+			)`, userIDType, userIDType),
 			`CREATE UNIQUE INDEX idx_sessions_token_hash ON sessions(token_hash)`,
 			`CREATE INDEX idx_sessions_user_id ON sessions(user_id)`,
 			`CREATE INDEX idx_sessions_expires_at ON sessions(expires_at)`,

--- a/apiserver/internal/migrations/007_sessions.go
+++ b/apiserver/internal/migrations/007_sessions.go
@@ -47,17 +47,25 @@ func (m *SessionsMigration) Up(ctx context.Context, db *gorm.DB) error {
 		}
 		return nil
 	case "mysql":
-		return dbCtx.Exec(`CREATE TABLE sessions (
-			id INT AUTO_INCREMENT PRIMARY KEY,
-			user_id INT NOT NULL,
-			token_hash VARCHAR(64) NOT NULL,
-			expires_at DATETIME NOT NULL,
-			created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-			UNIQUE INDEX idx_sessions_token_hash (token_hash),
-			INDEX idx_sessions_user_id (user_id),
-			INDEX idx_sessions_expires_at (expires_at),
-			FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
-		)`).Error
+		stmts := []string{
+			`CREATE TABLE sessions (
+				id INTEGER PRIMARY KEY AUTO_INCREMENT,
+				user_id INTEGER NOT NULL,
+				token_hash VARCHAR(64) NOT NULL,
+				expires_at DATETIME NOT NULL,
+				created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+				CONSTRAINT fk_users_sessions FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+			)`,
+			`CREATE UNIQUE INDEX idx_sessions_token_hash ON sessions(token_hash)`,
+			`CREATE INDEX idx_sessions_user_id ON sessions(user_id)`,
+			`CREATE INDEX idx_sessions_expires_at ON sessions(expires_at)`,
+		}
+		for _, stmt := range stmts {
+			if err := dbCtx.Exec(stmt).Error; err != nil {
+				return err
+			}
+		}
+		return nil
 	default:
 		return fmt.Errorf("unsupported dialect: %s", dialect)
 	}


### PR DESCRIPTION
## Problem

Migration 7 (sessions) fails on MySQL/MariaDB with:

```nError 1005 (HY000): Can't create table `tasks`.`sessions` (errno: 150 \"Foreign key constraint is incorrectly formed\")
```

On an affected deployment, `users.id` is `bigint(20)` (MariaDB), while migration 7 declared `sessions.user_id` as `INT` — type mismatch causes the FK to be rejected.

## Fix

- Use `INTEGER` for `sessions.id` and `sessions.user_id` (matches `users.id` declaration in migration 1, same pattern used by `labels.created_by` and `tasks.created_by` which FK successfully).
- Name the FK constraint (`fk_users_sessions`) for parity with other tables.
- Create indexes as separate statements after `CREATE TABLE` (matches the working `app_tokens` migration pattern).

No schema changes for SQLite path.
