### PR TITLE
feat(android): add search to task list screen

### DIFF
--- a/android/app/src/main/java/com/dkhalife/tasks/ui/navigation/AppNavigation.kt
+++ b/android/app/src/main/java/com/dkhalife/tasks/ui/navigation/AppNavigation.kt
@@ -133,6 +133,8 @@ fun AppNavigation(
                 val deletionRequestedAt by userViewModel.deletionRequestedAt.collectAsState()
                 val isOnline by viewModel.isOnline.collectAsState()
                 val pendingSyncCount by viewModel.pendingSyncCount.collectAsState()
+                val searchQuery by viewModel.searchQuery.collectAsState()
+                val isSearchActive by viewModel.isSearchActive.collectAsState()
 
                 LaunchedEffect(taskGrouping) {
                     viewModel.setTaskGrouping(taskGrouping)
@@ -151,6 +153,10 @@ fun AppNavigation(
                     onViewHistory = { navController.navigate(Routes.taskHistory(it)) },
                     onCreateTask = { navController.navigate(Routes.TASK_FORM_CREATE) },
                     onToggleGroup = { viewModel.toggleGroupExpanded(it) },
+                    searchQuery = searchQuery,
+                    isSearchActive = isSearchActive,
+                    onSearchQueryChange = { viewModel.setSearchQuery(it) },
+                    onSearchActiveChange = { viewModel.setSearchActive(it) },
                     swipeSettings = swipeSettings,
                     inlineCompleteEnabled = inlineCompleteEnabled,
                     isPendingDeletion = deletionRequestedAt != null,

--- a/android/app/src/main/java/com/dkhalife/tasks/ui/screen/TaskListScreen.kt
+++ b/android/app/src/main/java/com/dkhalife/tasks/ui/screen/TaskListScreen.kt
@@ -17,24 +17,41 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.CheckCircleOutline
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExtendedFloatingActionButton
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.LargeTopAppBar
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
 import com.dkhalife.tasks.R
 import com.dkhalife.tasks.data.SwipeSettings
@@ -58,6 +75,10 @@ fun TaskListScreen(
     onViewHistory: (Int) -> Unit,
     onCreateTask: () -> Unit,
     onToggleGroup: (String) -> Unit,
+    searchQuery: String = "",
+    isSearchActive: Boolean = false,
+    onSearchQueryChange: (String) -> Unit = {},
+    onSearchActiveChange: (Boolean) -> Unit = {},
     swipeSettings: SwipeSettings = SwipeSettings(),
     inlineCompleteEnabled: Boolean = true,
     isPendingDeletion: Boolean = false,
@@ -66,18 +87,104 @@ fun TaskListScreen(
 ){
     val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior()
     val newTaskLabel = stringResource(R.string.btn_new_task)
+    val focusRequester = remember { FocusRequester() }
+
+    // TextFieldValue is kept locally to preserve cursor position — only .text is pushed to the
+    // ViewModel, so the ViewModel never drives the cursor back, preventing cursor-jump bugs.
+    // Using only isSearchActive as the remember key prevents the state being recreated on every
+    // keystroke (which would happen if searchQuery were a key).
+    var textFieldValue by remember(isSearchActive) {
+        mutableStateOf(TextFieldValue(searchQuery, TextRange(searchQuery.length)))
+    }
+
+    // Re-sync from ViewModel only when the text differs (e.g. navigation restoration), not during
+    // normal typing where textFieldValue.text already matches searchQuery.
+    LaunchedEffect(searchQuery) {
+        if (textFieldValue.text != searchQuery) {
+            textFieldValue = TextFieldValue(searchQuery, TextRange(searchQuery.length))
+        }
+    }
+
+    LaunchedEffect(isSearchActive) {
+        if (isSearchActive) {
+            focusRequester.requestFocus()
+        }
+    }
 
     Scaffold(
-        modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
+        modifier = if (!isSearchActive) Modifier.nestedScroll(scrollBehavior.nestedScrollConnection) else Modifier,
         topBar = {
-            LargeTopAppBar(
-                title = { Text(stringResource(R.string.nav_tasks)) },
-                scrollBehavior = scrollBehavior,
-                colors = TopAppBarDefaults.topAppBarColors(
-                    containerColor = MaterialTheme.colorScheme.background,
-                    scrolledContainerColor = MaterialTheme.colorScheme.surface
-                )
-            )
+            AnimatedContent(
+                targetState = isSearchActive,
+                transitionSpec = { fadeIn() togetherWith fadeOut() },
+                label = "top-bar-search-transition"
+            ) { searching ->
+                if (searching) {
+                    TopAppBar(
+                        title = {
+                            BasicTextField(
+                                value = textFieldValue,
+                                onValueChange = { newValue ->
+                                    textFieldValue = newValue
+                                    onSearchQueryChange(newValue.text)
+                                },
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .focusRequester(focusRequester),
+                                textStyle = MaterialTheme.typography.bodyLarge.copy(
+                                    color = MaterialTheme.colorScheme.onSurface
+                                ),
+                                cursorBrush = SolidColor(MaterialTheme.colorScheme.primary),
+                                singleLine = true,
+                                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
+                                decorationBox = { innerTextField ->
+                                    Box {
+                                        if (textFieldValue.text.isEmpty()) {
+                                            Text(
+                                                text = stringResource(R.string.search_hint),
+                                                style = MaterialTheme.typography.bodyLarge,
+                                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                                            )
+                                        }
+                                        innerTextField()
+                                    }
+                                }
+                            )
+                        },
+                        actions = {
+                            IconButton(onClick = {
+                                textFieldValue = TextFieldValue("")
+                                onSearchActiveChange(false)
+                            }) {
+                                Icon(
+                                    Icons.Default.Close,
+                                    contentDescription = stringResource(R.string.search_clear_description)
+                                )
+                            }
+                        },
+                        colors = TopAppBarDefaults.topAppBarColors(
+                            containerColor = MaterialTheme.colorScheme.background,
+                        )
+                    )
+                } else {
+                    LargeTopAppBar(
+                        title = { Text(stringResource(R.string.nav_tasks)) },
+                        scrollBehavior = scrollBehavior,
+                        actions = {
+                            IconButton(onClick = { onSearchActiveChange(true) }) {
+                                Icon(
+                                    Icons.Default.Search,
+                                    contentDescription = stringResource(R.string.search_icon_description)
+                                )
+                            }
+                        },
+                        colors = TopAppBarDefaults.topAppBarColors(
+                            containerColor = MaterialTheme.colorScheme.background,
+                            scrolledContainerColor = MaterialTheme.colorScheme.surface
+                        )
+                    )
+                }
+            }
         },
         floatingActionButton = {
             if (!isPendingDeletion) {
@@ -145,17 +252,31 @@ fun TaskListScreen(
                                 tint = MaterialTheme.colorScheme.primary.copy(alpha = 0.6f)
                             )
                             Spacer(modifier = Modifier.height(16.dp))
-                            Text(
-                                text = stringResource(R.string.task_list_empty_title),
-                                style = MaterialTheme.typography.titleMedium,
-                                color = MaterialTheme.colorScheme.onSurface
-                            )
-                            Spacer(modifier = Modifier.height(4.dp))
-                            Text(
-                                text = stringResource(R.string.task_list_empty_hint, newTaskLabel),
-                                style = MaterialTheme.typography.bodyMedium,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant
-                            )
+                            if (isSearchActive && searchQuery.isNotBlank()) {
+                                Text(
+                                    text = stringResource(R.string.search_no_results_title),
+                                    style = MaterialTheme.typography.titleMedium,
+                                    color = MaterialTheme.colorScheme.onSurface
+                                )
+                                Spacer(modifier = Modifier.height(4.dp))
+                                Text(
+                                    text = stringResource(R.string.search_no_results_hint),
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                            } else {
+                                Text(
+                                    text = stringResource(R.string.task_list_empty_title),
+                                    style = MaterialTheme.typography.titleMedium,
+                                    color = MaterialTheme.colorScheme.onSurface
+                                )
+                                Spacer(modifier = Modifier.height(4.dp))
+                                Text(
+                                    text = stringResource(R.string.task_list_empty_hint, newTaskLabel),
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                            }
                         }
                     }
                 } else {

--- a/android/app/src/main/java/com/dkhalife/tasks/ui/screen/TaskListScreen.kt
+++ b/android/app/src/main/java/com/dkhalife/tasks/ui/screen/TaskListScreen.kt
@@ -147,6 +147,7 @@ fun TaskListScreen(
                                 colors = TextFieldDefaults.colors(
                                     focusedContainerColor = Color.Transparent,
                                     unfocusedContainerColor = Color.Transparent,
+                                    disabledContainerColor = Color.Transparent,
                                     focusedIndicatorColor = Color.Transparent,
                                     unfocusedIndicatorColor = Color.Transparent,
                                     disabledIndicatorColor = Color.Transparent,

--- a/android/app/src/main/java/com/dkhalife/tasks/ui/screen/TaskListScreen.kt
+++ b/android/app/src/main/java/com/dkhalife/tasks/ui/screen/TaskListScreen.kt
@@ -17,7 +17,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
@@ -33,6 +32,8 @@ import androidx.compose.material3.LargeTopAppBar
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
@@ -46,7 +47,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
-import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextRange
@@ -122,7 +123,7 @@ fun TaskListScreen(
                 if (searching) {
                     TopAppBar(
                         title = {
-                            BasicTextField(
+                            TextField(
                                 value = textFieldValue,
                                 onValueChange = { newValue ->
                                     textFieldValue = newValue
@@ -131,24 +132,25 @@ fun TaskListScreen(
                                 modifier = Modifier
                                     .fillMaxWidth()
                                     .focusRequester(focusRequester),
+                                placeholder = {
+                                    Text(
+                                        text = stringResource(R.string.search_hint),
+                                        style = MaterialTheme.typography.bodyLarge,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                                    )
+                                },
                                 textStyle = MaterialTheme.typography.bodyLarge.copy(
                                     color = MaterialTheme.colorScheme.onSurface
                                 ),
-                                cursorBrush = SolidColor(MaterialTheme.colorScheme.primary),
                                 singleLine = true,
                                 keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
-                                decorationBox = { innerTextField ->
-                                    Box {
-                                        if (textFieldValue.text.isEmpty()) {
-                                            Text(
-                                                text = stringResource(R.string.search_hint),
-                                                style = MaterialTheme.typography.bodyLarge,
-                                                color = MaterialTheme.colorScheme.onSurfaceVariant
-                                            )
-                                        }
-                                        innerTextField()
-                                    }
-                                }
+                                colors = TextFieldDefaults.colors(
+                                    focusedContainerColor = Color.Transparent,
+                                    unfocusedContainerColor = Color.Transparent,
+                                    focusedIndicatorColor = Color.Transparent,
+                                    unfocusedIndicatorColor = Color.Transparent,
+                                    disabledIndicatorColor = Color.Transparent,
+                                )
                             )
                         },
                         actions = {

--- a/android/app/src/main/java/com/dkhalife/tasks/viewmodel/TaskListViewModel.kt
+++ b/android/app/src/main/java/com/dkhalife/tasks/viewmodel/TaskListViewModel.kt
@@ -62,6 +62,12 @@ class TaskListViewModel @Inject constructor(
     private val _expandedGroups = MutableStateFlow(groupingRepository.getExpandedGroups())
     val expandedGroups: StateFlow<Set<String>> = _expandedGroups
 
+    private val _searchQuery = MutableStateFlow("")
+    val searchQuery: StateFlow<String> = _searchQuery
+
+    private val _isSearchActive = MutableStateFlow(false)
+    val isSearchActive: StateFlow<Boolean> = _isSearchActive
+
     init {
         refreshTasks()
         collectWebSocketMessages()
@@ -73,6 +79,17 @@ class TaskListViewModel @Inject constructor(
         _taskGrouping.value = grouping
         _expandedGroups.value = emptySet()
         groupingRepository.setExpandedGroups(emptySet())
+    }
+
+    fun setSearchQuery(query: String) {
+        _searchQuery.value = query
+    }
+
+    fun setSearchActive(active: Boolean) {
+        _isSearchActive.value = active
+        if (!active) {
+            _searchQuery.value = ""
+        }
     }
 
     fun toggleGroupExpanded(groupKey: String) {
@@ -88,8 +105,9 @@ class TaskListViewModel @Inject constructor(
 
     private fun observeGrouping() {
         viewModelScope.launch {
-            combine(tasks, _taskGrouping, labelRepository.labels) { tasks, grouping, labels ->
-                computeGroups(tasks, grouping, labels)
+            combine(tasks, _taskGrouping, labelRepository.labels, _searchQuery) { tasks, grouping, labels, query ->
+                val filtered = if (query.isBlank()) tasks else tasks.filter { it.title.contains(query, ignoreCase = true) }
+                computeGroups(filtered, grouping, labels)
             }.flowOn(Dispatchers.Default).collect { groups ->
                 _taskGroups.value = groups
             }

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -61,6 +61,11 @@
     <!-- Task list screen -->
     <string name="task_list_empty_title">All caught up!</string>
     <string name="task_list_empty_hint">Tap \"%1$s\" to create one</string>
+    <string name="search_hint">Search tasks…</string>
+    <string name="search_no_results_title">No tasks match your search</string>
+    <string name="search_no_results_hint">Try a different search term</string>
+    <string name="search_icon_description">Search</string>
+    <string name="search_clear_description">Clear search</string>
 
     <!-- Labels screen -->
     <string name="labels_empty_title">No labels yet</string>


### PR DESCRIPTION
## Summary

Adds search functionality to the Android task list screen.

## Behavior

- **Search icon** (🔍) in the top-right of the app bar; tapping it animates the bar into a search field that takes focus automatically
- **Full-width text field** replaces the collapsing title bar during search; an **✕ icon** replaces the search icon and cancels search + clears the query
- **Substring match** (case-insensitive) on task title; groups with no matching tasks are hidden automatically
- **Navigation persistence**: search state lives in the ViewModel so navigating to task details and pressing back restores the filtered view
- **Cold-start reset**: state is not persisted to disk — reopening the app shows no active search

## Cursor-jump bug prevention

Previous patterns drove `TextField` from a ViewModel `String`, which recreated `TextFieldValue` without cursor info on every keystroke. This implementation keeps `TextFieldValue` (including cursor/selection) as local `remember(isSearchActive)` state. Only `.text` is pushed to the ViewModel. A `LaunchedEffect(searchQuery)` re-syncs the local value only when `textFieldValue.text != searchQuery` (navigation restoration), never during normal typing.

## Files changed

| File | Change |
|------|--------|
| `TaskListViewModel.kt` | Add `_searchQuery` / `_isSearchActive` StateFlows + setters; inject into `combine` for reactive filtering |
| `TaskListScreen.kt` | Search UI: animated top bar swap, `BasicTextField`, focus management, search-aware empty state |
| `AppNavigation.kt` | Collect and wire search state/handlers to `TaskListScreen` |
| `strings.xml` | Add search hint, no-results strings, icon content descriptions |
