### PR TITLE
fix(security): add ownership checks to CompleteTask and SkipTask

### DIFF
--- a/apiserver/internal/services/tasks/task.go
+++ b/apiserver/internal/services/tasks/task.go
@@ -363,6 +363,13 @@ func (s *TaskService) SkipTask(ctx context.Context, userID, taskID int) (int, in
 		}
 	}
 
+	if userID != task.CreatedBy {
+		telemetry.TrackWarning(ctx, "task_forbidden", "task-service", "User not allowed to skip task", nil)
+		return http.StatusForbidden, gin.H{
+			"error": "You are not allowed to skip this task",
+		}
+	}
+
 	nextDueDate, err := tRepo.ScheduleNextDueDate(task, task.NextDueDate.UTC())
 	if err != nil {
 		log.Errorf("error scheduling next due date: %s", err.Error())
@@ -469,6 +476,13 @@ func (s *TaskService) CompleteTask(ctx context.Context, userID, taskID int, endR
 		telemetry.TrackError(ctx, "task_get_failed", "task-service", err, nil)
 		return http.StatusInternalServerError, gin.H{
 			"error": "Error getting task",
+		}
+	}
+
+	if userID != task.CreatedBy {
+		telemetry.TrackWarning(ctx, "task_forbidden", "task-service", "User not allowed to complete task", nil)
+		return http.StatusForbidden, gin.H{
+			"error": "You are not allowed to complete this task",
 		}
 	}
 


### PR DESCRIPTION
## Security Fix

`CompleteTask` and `SkipTask` were missing BOLA (Broken Object Level Authorization) checks. Any authenticated user could complete or skip another user's task if they knew the task ID, because neither method verified that the requesting user owned the task before acting on it.

This fix adds ownership validation consistent with `EditTask`, `UncompleteTask`, and `UpdateDueDate`, which already enforce this check correctly.

## Changes

- `CompleteTask`: return 403 Forbidden if the requesting user does not own the task
- `SkipTask`: return 403 Forbidden if the requesting user does not own the task