### PR TITLE
fix(safety): guard against nil NextDueDate in SkipTask

### DIFF
--- a/apiserver/internal/repos/task/task.go
+++ b/apiserver/internal/repos/task/task.go
@@ -196,9 +196,14 @@ func ScheduleNextDueDate(task *models.Task, completedDate time.Time) (*time.Time
 		return nil, nil
 	}
 
-	var baseDate time.Time = *task.NextDueDate
+	var baseDate time.Time
 	if task.IsRolling {
 		baseDate = completedDate
+	} else {
+		if task.NextDueDate == nil {
+			return nil, errors.New("task has no next due date")
+		}
+		baseDate = *task.NextDueDate
 	}
 
 	if baseDate.IsZero() {

--- a/apiserver/internal/repos/task/task_test.go
+++ b/apiserver/internal/repos/task/task_test.go
@@ -448,6 +448,7 @@ func (s *TaskTestSuite) TestScheduleNextDueDate() {
 		completedDate time.Time
 		expectedType  string
 		expectedDelta time.Duration
+		expectError   bool
 	}{
 		{
 			name: "Once frequency",
@@ -548,13 +549,41 @@ func (s *TaskTestSuite) TestScheduleNextDueDate() {
 			completedDate: now,
 			expectedType:  "nil", // Should not calculate a next due date
 		},
+		{
+			name: "Nil NextDueDate with non-rolling task",
+			task: &models.Task{
+				NextDueDate: nil,
+				IsRolling:   false,
+				Frequency: models.Frequency{
+					Type: models.RepeatDaily,
+				},
+			},
+			completedDate: now,
+			expectError:   true,
+		},
+		{
+			name: "Nil NextDueDate with rolling task",
+			task: &models.Task{
+				NextDueDate: nil,
+				IsRolling:   true,
+				Frequency: models.Frequency{
+					Type: models.RepeatDaily,
+				},
+			},
+			completedDate: now,
+			expectedType:  "time",
+			expectedDelta: 24 * time.Hour,
+		},
 	}
 
 	for _, tc := range testCases {
 		s.Run(tc.name, func() {
 			nextDueDate, err := ScheduleNextDueDate(tc.task, tc.completedDate)
 
-			if tc.expectedType == "nil" {
+			if tc.expectError {
+				s.Require().Error(err)
+				s.Nil(nextDueDate)
+			} else if tc.expectedType == "nil" {
 				s.Nil(nextDueDate)
 				s.Nil(err)
 			} else {

--- a/apiserver/internal/services/tasks/task.go
+++ b/apiserver/internal/services/tasks/task.go
@@ -363,6 +363,13 @@ func (s *TaskService) SkipTask(ctx context.Context, userID, taskID int) (int, in
 		}
 	}
 
+	if task.NextDueDate == nil {
+		telemetry.TrackWarning(ctx, "task_skip_failed", "task-service", "Task has no due date to skip", nil)
+		return http.StatusBadRequest, gin.H{
+			"error": "Task has no due date to skip",
+		}
+	}
+
 	nextDueDate, err := tRepo.ScheduleNextDueDate(task, task.NextDueDate.UTC())
 	if err != nil {
 		log.Errorf("error scheduling next due date: %s", err.Error())


### PR DESCRIPTION
## Bug Fix

`SkipTask` and `ScheduleNextDueDate` could panic with a nil pointer dereference when a task has no due date (`NextDueDate == nil`). This can occur for completed one-time tasks or tasks whose end date has passed.

## Changes

- `SkipTask`: return 400 Bad Request when the task has no due date instead of panicking
- `ScheduleNextDueDate`: guard the `*task.NextDueDate` dereference and return an error when nil and not rolling