### PR TITLE
fix(quality): return 404 instead of 500 when task is not found

### DIFF
--- a/apiserver/internal/services/tasks/task.go
+++ b/apiserver/internal/services/tasks/task.go
@@ -123,6 +123,9 @@ func (s *TaskService) GetTask(ctx context.Context, userID, taskID int) (int, int
 
 	task, err := s.t.GetTask(ctx, taskID)
 	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return http.StatusNotFound, gin.H{"error": "Task not found"}
+		}
 		log.Errorf("error getting task: %s", err.Error())
 		telemetry.TrackError(ctx, "task_get_failed", "task-service", err, nil)
 		return http.StatusInternalServerError, gin.H{
@@ -267,6 +270,9 @@ func (s *TaskService) EditTask(ctx context.Context, userID int, req models.Updat
 	oldTask, err := s.t.GetTask(ctx, taskId)
 
 	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return http.StatusNotFound, gin.H{"error": "Task not found"}
+		}
 		log.Errorf("error getting task: %s", err.Error())
 		telemetry.TrackError(ctx, "task_get_failed", "task-service", err, nil)
 		return http.StatusInternalServerError, gin.H{
@@ -356,6 +362,9 @@ func (s *TaskService) SkipTask(ctx context.Context, userID, taskID int) (int, in
 	log := logging.FromContext(ctx)
 	task, err := s.t.GetTask(ctx, taskID)
 	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return http.StatusNotFound, gin.H{"error": "Task not found"}
+		}
 		log.Errorf("error getting task: %s", err.Error())
 		telemetry.TrackError(ctx, "task_get_failed", "task-service", err, nil)
 		return http.StatusInternalServerError, gin.H{
@@ -409,6 +418,9 @@ func (s *TaskService) UpdateDueDate(ctx context.Context, userID, taskID int, req
 
 	task, err := s.t.GetTask(ctx, taskID)
 	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return http.StatusNotFound, gin.H{"error": "Task not found"}
+		}
 		log.Errorf("error getting task: %s", err.Error())
 		telemetry.TrackError(ctx, "task_get_failed", "task-service", err, nil)
 		return http.StatusInternalServerError, gin.H{
@@ -465,6 +477,9 @@ func (s *TaskService) CompleteTask(ctx context.Context, userID, taskID int, endR
 
 	task, err := s.t.GetTask(ctx, taskID)
 	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return http.StatusNotFound, gin.H{"error": "Task not found"}
+		}
 		log.Errorf("error getting task: %s", err.Error())
 		telemetry.TrackError(ctx, "task_get_failed", "task-service", err, nil)
 		return http.StatusInternalServerError, gin.H{
@@ -522,6 +537,9 @@ func (s *TaskService) UncompleteTask(ctx context.Context, userID, taskID int) (i
 	log := logging.FromContext(ctx)
 	task, err := s.t.GetTask(ctx, taskID)
 	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return http.StatusNotFound, gin.H{"error": "Task not found"}
+		}
 		log.Errorf("error getting task: %s", err.Error())
 		telemetry.TrackError(ctx, "task_get_failed", "task-service", err, nil)
 		return http.StatusInternalServerError, gin.H{


### PR DESCRIPTION
## Quality Fix

Several task service methods were returning HTTP 500 (Internal Server Error) when a requested task did not exist. The correct response for a missing resource is HTTP 404 (Not Found).

## Changes

Added `gorm.ErrRecordNotFound` checks to the following methods in the task service, so they return 404 instead of 500 when the task doesn't exist:

- `GetTask`
- `EditTask`
- `CompleteTask`
- `SkipTask`
- `UpdateDueDate`
- `UncompleteTask` (initial fetch)