### PR TITLE
Log dropped WebSocket messages when socket is not connected

### DIFF
--- a/android/app/src/main/java/com/dkhalife/tasks/ws/WebSocketManager.kt
+++ b/android/app/src/main/java/com/dkhalife/tasks/ws/WebSocketManager.kt
@@ -74,8 +74,10 @@ class WebSocketManager @Inject constructor(
             data = data
         )
         val sent = webSocket?.send(gson.toJson(message))
-        if (sent == false) {
-            telemetryManager.logWarning(TAG, "Failed to send WebSocket message: action=$action, requestId=$requestId")
+        when (sent) {
+            null -> telemetryManager.logWarning(TAG, "Dropped WebSocket message (not connected): action=$action, requestId=$requestId")
+            false -> telemetryManager.logWarning(TAG, "Failed to send WebSocket message: action=$action, requestId=$requestId")
+            true -> Unit
         }
         return requestId
     }


### PR DESCRIPTION
`WebSocketManager.sendAction` checked `sent == false` to detect send failures, but `webSocket?.send(...)` returns `Boolean?`. When `webSocket` is `null` (pre-connect, post-disconnect, mid-reconnect), `sent` is `null`, and `null == false` evaluates to `false` — so the warning never fired and any action submitted while disconnected was silently dropped.

Replace the `if` check with an exhaustive `when` over the nullable boolean so both the not-connected (`null`) and send-rejected (`false`) cases are logged, with distinct messages to make the cause clear.