### PR TITLE
Fix NPE risk on empty Retrofit response body in repos

### DIFF
--- a/android/app/src/main/java/com/dkhalife/tasks/repo/TaskRepository.kt
+++ b/android/app/src/main/java/com/dkhalife/tasks/repo/TaskRepository.kt
@@ -86,7 +86,13 @@ class TaskRepository @Inject constructor(
         return try {
             val response = api.getTask(id)
             if (response.isSuccessful) {
-                Result.success(response.body()!!.task)
+                val task = response.body()?.task
+                if (task != null) {
+                    Result.success(task)
+                } else {
+                    telemetryManager.logError(TAG, "Failed to fetch task: empty body")
+                    Result.failure(Exception("Failed to fetch task: empty body"))
+                }
             } else {
                 Result.failure(Exception("Failed to fetch task: ${response.code()}"))
             }

--- a/android/app/src/main/java/com/dkhalife/tasks/repo/UserRepository.kt
+++ b/android/app/src/main/java/com/dkhalife/tasks/repo/UserRepository.kt
@@ -15,7 +15,13 @@ class UserRepository @Inject constructor(
         return try {
             val response = api.getUserProfile()
             if (response.isSuccessful) {
-                Result.success(response.body()!!.user)
+                val user = response.body()?.user
+                if (user != null) {
+                    Result.success(user)
+                } else {
+                    telemetryManager.logError(TAG, "Failed to fetch profile: empty body")
+                    Result.failure(Exception("Failed to fetch profile: empty body"))
+                }
             } else {
                 telemetryManager.logError(TAG, "Failed to fetch profile: ${response.code()}")
                 Result.failure(Exception("Failed to fetch profile: ${response.code()}"))


### PR DESCRIPTION
## Summary

`TaskRepository.getTask` and `UserRepository.getUserProfile` dereferenced `response.body()` with `!!` even though `isSuccessful` does not guarantee a non-null body. Retrofit can return a 2xx with a null body (e.g. deserialization failure or empty server response), which would crash the app with an NPE.

Both call sites now use the null-safe pattern already established in `TaskRepository.refreshCompletedTasks`: log the error via `telemetryManager.logError` and return `Result.failure(...)` with an `"empty body"` message.

## Changes

- `android/app/src/main/java/com/dkhalife/tasks/repo/TaskRepository.kt` — `getTask(id)` null-checks `response.body()?.task`.
- `android/app/src/main/java/com/dkhalife/tasks/repo/UserRepository.kt` — `getUserProfile()` null-checks `response.body()?.user`.

## Verification

Gradle/Java was unavailable in the build environment, so compilation was verified by inspection — the changes mirror the existing pattern in `refreshCompletedTasks` and only touch the two affected branches.