### PR TITLE
Propagate sync failures from SyncCoordinator.syncOnceBlocking

### DIFF
--- a/android/app/src/main/java/com/dkhalife/tasks/data/sync/SyncCoordinator.kt
+++ b/android/app/src/main/java/com/dkhalife/tasks/data/sync/SyncCoordinator.kt
@@ -76,11 +76,13 @@ class SyncCoordinator @Inject constructor(
             it.join()
             return true
         }
+        var success = false
         val job = scope.launch {
             mutex.withLock {
                 try {
                     flushOutbox()
                     refreshAll()
+                    success = true
                 } catch (e: Exception) {
                     telemetryManager.logError(TAG, "Sync cycle failed: ${e.message}", e)
                 }
@@ -88,7 +90,7 @@ class SyncCoordinator @Inject constructor(
         }
         activeFullJob = job
         job.join()
-        return true
+        return success
     }
 
     /**

--- a/android/app/src/main/java/com/dkhalife/tasks/repo/TaskRepository.kt
+++ b/android/app/src/main/java/com/dkhalife/tasks/repo/TaskRepository.kt
@@ -56,8 +56,12 @@ class TaskRepository @Inject constructor(
             return Result.success(tasks.value)
         }
         return try {
-            syncCoordinator.syncOnceBlocking()
-            Result.success(tasks.value)
+            val ok = syncCoordinator.syncOnceBlocking()
+            if (ok) {
+                Result.success(tasks.value)
+            } else {
+                Result.failure(Exception("Sync cycle failed"))
+            }
         } catch (e: Exception) {
             telemetryManager.logError(TAG, "Failed to refresh tasks: ${e.message}", e)
             Result.failure(e)


### PR DESCRIPTION
`SyncCoordinator.syncOnceBlocking()` previously caught exceptions inside the launched coroutine and always returned `true`. Callers like `TaskRepository.refreshTasks` then surfaced stale local data as if the refresh had succeeded.

This change captures the real outcome of the sync cycle and returns it, and updates `TaskRepository.refreshTasks` to propagate the failure as a `Result.failure(...)`. The in-flight-join branch still returns `true` since the caller will eventually observe the shared DB state.

Verified with `./gradlew :app:compileDebugKotlin --no-daemon`.