### PR TITLE
Clean up old ACR images during release

### DIFF
--- a/.github/workflows/full-release.yml
+++ b/.github/workflows/full-release.yml
@@ -152,6 +152,26 @@ jobs:
           tags: ${{ secrets.ACR_NAME }}.azurecr.io/task-wizard-mcp:canary, ${{ secrets.ACR_NAME }}.azurecr.io/task-wizard-mcp:${{ github.ref_name }}
           platforms: linux/amd64
 
+      - name: Cleanup old ACR images
+        run: |
+          CUTOFF_DATE=$(date -u -d '3 days ago' +%Y-%m-%dT%H:%M:%SZ)
+          echo "Cleaning up images older than $CUTOFF_DATE"
+
+          for REPO in task-wizard-api task-wizard-mcp; do
+            echo "Scanning $REPO"
+            az acr manifest list-metadata \
+              --registry ${{ secrets.ACR_NAME }} \
+              --name "$REPO" \
+              --query "[?lastUpdateTime<'$CUTOFF_DATE' && !contains(tags, 'canary') && !contains(tags, 'release')].digest" \
+              -o tsv | \
+            while read digest; do
+              if [ -n "$digest" ]; then
+                echo "Deleting $REPO@$digest"
+                az acr repository delete --name ${{ secrets.ACR_NAME }} --image "$REPO@$digest" --yes
+              fi
+            done
+          done
+
       - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:


### PR DESCRIPTION
Adds an ACR cleanup step to the canary release job in `full-release.yml`

After the API and MCP images are pushed, the new step iterates both `task-wizard-api` and `task-wizard-mcp` repositories and deletes any manifest whose `lastUpdateTime` is older than 3 days, while preserving manifests tagged `canary` or `release` so the active deployment targets are never removed.

This keeps the registry from accumulating stale per-version images over time.