### PR TITLE
Add Esc shortcut to cancel task edit

### DIFF
--- a/frontend/src/views/Modals/Inputs/ConfirmationModal.tsx
+++ b/frontend/src/views/Modals/Inputs/ConfirmationModal.tsx
@@ -45,6 +45,10 @@ export class ConfirmationModal extends React.Component<
     }
   }
 
+  public get isOpen(): boolean {
+    return this.state.isOpen
+  }
+
   public async open(onClose: ConfirmedHandler): Promise<void> {
     await this.setState({
       isOpen: true,

--- a/frontend/src/views/Tasks/TaskEdit.tsx
+++ b/frontend/src/views/Tasks/TaskEdit.tsx
@@ -227,6 +227,19 @@ class TaskEditImpl extends React.Component<TaskEditProps, TaskEditState> {
     this.init()
 
     moveFocusToJoyInput(this.titleInputRef)
+
+    document.addEventListener('keydown', this.onKeyDown)
+  }
+
+  componentWillUnmount(): void {
+    document.removeEventListener('keydown', this.onKeyDown)
+  }
+
+  private onKeyDown = (e: KeyboardEvent) => {
+    if (e.key === 'Escape') {
+      e.preventDefault()
+      this.onCancelClicked()
+    }
   }
 
   private onTitleChanged = (e: ChangeEvent<HTMLInputElement>) => {

--- a/frontend/src/views/Tasks/TaskEdit.tsx
+++ b/frontend/src/views/Tasks/TaskEdit.tsx
@@ -236,10 +236,16 @@ class TaskEditImpl extends React.Component<TaskEditProps, TaskEditState> {
   }
 
   private onKeyDown = (e: KeyboardEvent) => {
-    if (e.key === 'Escape') {
-      e.preventDefault()
-      this.onCancelClicked()
+    if (e.key !== 'Escape' || e.defaultPrevented) {
+      return
     }
+
+    if (this.confirmModalRef.current?.isOpen) {
+      return
+    }
+
+    e.preventDefault()
+    this.onCancelClicked()
   }
 
   private onTitleChanged = (e: ChangeEvent<HTMLInputElement>) => {


### PR DESCRIPTION
Editing or creating a task previously required clicking the Cancel button to back out. This adds an `Esc` keyboard shortcut so users can quickly dismiss the task edit view without reaching for the mouse.

The `TaskEdit` component now registers a `keydown` listener on mount and removes it on unmount. Pressing `Escape` triggers the same `onCancelClicked` handler used by the Cancel button, navigating back to the home view.