### PR TITLE
Show session-expired banner on non-recoverable auth failure

### DIFF
--- a/android/app/src/main/java/com/dkhalife/tasks/api/AuthInterceptor.kt
+++ b/android/app/src/main/java/com/dkhalife/tasks/api/AuthInterceptor.kt
@@ -37,7 +37,7 @@ class AuthInterceptor(
             return null
         }
 
-        val freshToken = runBlocking { tokenProvider.getAccessToken() } ?: run {
+        val freshToken = runBlocking { tokenProvider.getAccessToken(forceRefresh = true) } ?: run {
             telemetryManager.logWarning(TAG, "Token refresh failed")
             return null
         }

--- a/android/app/src/main/java/com/dkhalife/tasks/auth/AuthManager.kt
+++ b/android/app/src/main/java/com/dkhalife/tasks/auth/AuthManager.kt
@@ -9,7 +9,10 @@ import com.microsoft.identity.client.IAuthenticationResult
 import com.microsoft.identity.client.ISingleAccountPublicClientApplication
 import com.microsoft.identity.client.SilentAuthenticationCallback
 import com.microsoft.identity.client.exception.MsalException
+import com.microsoft.identity.client.exception.MsalUiRequiredException
 import com.dkhalife.tasks.telemetry.TelemetryManager
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -31,6 +34,14 @@ class AuthManager @Inject constructor(
 
     @Volatile
     private var isAccountLoaded = false
+
+    private val _sessionExpired = MutableStateFlow(false)
+    /**
+     * Emits true when a silent token refresh fails non-recoverably (the MSAL refresh token is gone
+     * or revoked), meaning interactive sign-in is required. The account record still exists so
+     * [isSignedIn] stays true; this flag is how the UI learns the session has effectively expired.
+     */
+    val sessionExpired: StateFlow<Boolean> = _sessionExpired
 
     private val userChangeListeners = mutableListOf<UserChangeListener>()
 
@@ -68,6 +79,7 @@ class AuthManager @Inject constructor(
         if (account == null) {
             cachedAccessToken = null
             cachedExpiryTimeMs = 0
+            _sessionExpired.value = false
         }
         isAccountLoaded = true
         notifyUserChanged(account != null)
@@ -87,10 +99,12 @@ class AuthManager @Inject constructor(
         return null
     }
 
-    override suspend fun getAccessToken(): String? {
-        val token = cachedAccessToken
-        if (token != null && System.currentTimeMillis() < cachedExpiryTimeMs - TOKEN_SKEW_MS) {
-            return token
+    override suspend fun getAccessToken(forceRefresh: Boolean): String? {
+        if (!forceRefresh) {
+            val token = cachedAccessToken
+            if (token != null && System.currentTimeMillis() < cachedExpiryTimeMs - TOKEN_SKEW_MS) {
+                return token
+            }
         }
 
         val account = currentAccount ?: return null
@@ -102,6 +116,11 @@ class AuthManager @Inject constructor(
             result.accessToken
         } catch (e: MsalException) {
             telemetryManager.logWarning(TAG, "Silent token acquire failed: ${e.message}", e)
+            if (e is MsalUiRequiredException) {
+                cachedAccessToken = null
+                cachedExpiryTimeMs = 0
+                _sessionExpired.value = true
+            }
             null
         }
     }
@@ -168,6 +187,7 @@ class AuthManager @Inject constructor(
     private fun cacheToken(result: IAuthenticationResult) {
         cachedAccessToken = result.accessToken
         cachedExpiryTimeMs = result.expiresOn.time
+        _sessionExpired.value = false
     }
 
     companion object {

--- a/android/app/src/main/java/com/dkhalife/tasks/auth/AuthTokenProvider.kt
+++ b/android/app/src/main/java/com/dkhalife/tasks/auth/AuthTokenProvider.kt
@@ -1,6 +1,6 @@
 package com.dkhalife.tasks.auth
 
 interface AuthTokenProvider {
-    suspend fun getAccessToken(): String?
+    suspend fun getAccessToken(forceRefresh: Boolean = false): String?
     fun getCachedAccessToken(): String?
 }

--- a/android/app/src/main/java/com/dkhalife/tasks/ui/components/AuthErrorBanner.kt
+++ b/android/app/src/main/java/com/dkhalife/tasks/ui/components/AuthErrorBanner.kt
@@ -1,0 +1,70 @@
+package com.dkhalife.tasks.ui.components
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ErrorOutline
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.dkhalife.tasks.R
+
+@Composable
+fun AuthErrorBanner(
+    onReauthenticate: () -> Unit,
+    modifier: Modifier = Modifier,
+    isReauthenticating: Boolean = false,
+) {
+    Surface(
+        color = MaterialTheme.colorScheme.errorContainer,
+        modifier = modifier.fillMaxWidth(),
+    ) {
+        Row(
+            modifier = Modifier.padding(start = 16.dp, end = 8.dp, top = 8.dp, bottom = 8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(
+                Icons.Default.ErrorOutline,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onErrorContainer,
+                modifier = Modifier.size(20.dp),
+            )
+            Spacer(modifier = Modifier.width(12.dp))
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = stringResource(R.string.auth_error_session_expired_title),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onErrorContainer,
+                )
+                Text(
+                    text = stringResource(R.string.auth_error_session_expired_body),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onErrorContainer,
+                )
+            }
+            Spacer(modifier = Modifier.width(8.dp))
+            TextButton(
+                onClick = onReauthenticate,
+                enabled = !isReauthenticating,
+            ) {
+                Text(
+                    text = stringResource(R.string.auth_error_sign_in_action),
+                    color = MaterialTheme.colorScheme.onErrorContainer,
+                    style = MaterialTheme.typography.labelLarge,
+                )
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/dkhalife/tasks/ui/navigation/AppNavigation.kt
+++ b/android/app/src/main/java/com/dkhalife/tasks/ui/navigation/AppNavigation.kt
@@ -1,5 +1,6 @@
 package com.dkhalife.tasks.ui.navigation
 
+import android.app.Activity
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInHorizontally
@@ -19,6 +20,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavGraph.Companion.findStartDestination
@@ -127,6 +129,7 @@ fun AppNavigation(
             composable(Screen.Tasks.route) {
                 val viewModel: TaskListViewModel = hiltViewModel()
                 val userViewModel: UserViewModel = hiltViewModel()
+                val authViewModel: AuthViewModel = hiltViewModel()
                 val isRefreshing by viewModel.isRefreshing.collectAsState()
                 val taskGroups by viewModel.taskGroups.collectAsState()
                 val expandedGroups by viewModel.expandedGroups.collectAsState()
@@ -135,9 +138,22 @@ fun AppNavigation(
                 val pendingSyncCount by viewModel.pendingSyncCount.collectAsState()
                 val searchQuery by viewModel.searchQuery.collectAsState()
                 val isSearchActive by viewModel.isSearchActive.collectAsState()
+                val sessionExpired by authViewModel.sessionExpired.collectAsState()
+                val isReauthenticating by authViewModel.isLoading.collectAsState()
+                val activity = LocalContext.current as Activity
 
                 LaunchedEffect(taskGrouping) {
                     viewModel.setTaskGrouping(taskGrouping)
+                }
+
+                // When the session recovers (expired -> active) after re-authentication, pull fresh
+                // data so the user doesn't keep staring at the stale cache the failed syncs left behind.
+                var wasSessionExpired by remember { mutableStateOf(sessionExpired) }
+                LaunchedEffect(sessionExpired) {
+                    if (wasSessionExpired && !sessionExpired) {
+                        viewModel.refreshTasks()
+                    }
+                    wasSessionExpired = sessionExpired
                 }
 
                 TaskListScreen(
@@ -162,6 +178,9 @@ fun AppNavigation(
                     isPendingDeletion = deletionRequestedAt != null,
                     isOnline = isOnline,
                     pendingSyncCount = pendingSyncCount,
+                    sessionExpired = sessionExpired,
+                    isReauthenticating = isReauthenticating,
+                    onReauthenticate = { authViewModel.signIn(activity) },
                 )
             }
 

--- a/android/app/src/main/java/com/dkhalife/tasks/ui/screen/TaskListScreen.kt
+++ b/android/app/src/main/java/com/dkhalife/tasks/ui/screen/TaskListScreen.kt
@@ -57,6 +57,7 @@ import androidx.compose.ui.unit.dp
 import com.dkhalife.tasks.R
 import com.dkhalife.tasks.data.SwipeSettings
 import com.dkhalife.tasks.data.TaskGroup
+import com.dkhalife.tasks.ui.components.AuthErrorBanner
 import com.dkhalife.tasks.ui.components.GroupHeader
 import com.dkhalife.tasks.ui.components.SyncStatusBanner
 import com.dkhalife.tasks.ui.components.TaskItem
@@ -85,6 +86,9 @@ fun TaskListScreen(
     isPendingDeletion: Boolean = false,
     isOnline: Boolean = true,
     pendingSyncCount: Int = 0,
+    sessionExpired: Boolean = false,
+    isReauthenticating: Boolean = false,
+    onReauthenticate: () -> Unit = {},
 ){
     val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior()
     val newTaskLabel = stringResource(R.string.btn_new_task)
@@ -206,6 +210,12 @@ fun TaskListScreen(
                 .fillMaxSize()
                 .padding(padding)
         ) {
+            if (sessionExpired) {
+                AuthErrorBanner(
+                    onReauthenticate = onReauthenticate,
+                    isReauthenticating = isReauthenticating,
+                )
+            }
             SyncStatusBanner(isOnline = isOnline, pendingSyncCount = pendingSyncCount)
             if (isPendingDeletion) {
                 androidx.compose.material3.Surface(

--- a/android/app/src/main/java/com/dkhalife/tasks/viewmodel/AuthViewModel.kt
+++ b/android/app/src/main/java/com/dkhalife/tasks/viewmodel/AuthViewModel.kt
@@ -33,6 +33,8 @@ class AuthViewModel @Inject constructor(
     private val _serverEndpoint = MutableStateFlow(endpointProvider.getServerEndpoint())
     val serverEndpoint: StateFlow<String> = _serverEndpoint
 
+    val sessionExpired: StateFlow<Boolean> = authManager.sessionExpired
+
     private val userChangeListener = AuthManager.UserChangeListener { isSignedIn ->
         _isSignedIn.value = isSignedIn
         _isLoading.value = false

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -5,6 +5,10 @@
     <string name="sync_banner_offline_pending">Offline - %1$d change(s) pending sync.</string>
     <string name="sync_banner_pending">Syncing %1$d pending change(s)…</string>
 
+    <string name="auth_error_session_expired_title">Your session has expired</string>
+    <string name="auth_error_session_expired_body">Sign in again to keep your tasks in sync.</string>
+    <string name="auth_error_sign_in_action">Sign in</string>
+
     <!-- Widget metadata -->
     <string name="widget_task_list_name">Task List</string>
     <string name="widget_task_list_description">Scrollable grouped task list with quick complete</string>


### PR DESCRIPTION
## Why

On Android, when MSAL's silent token refresh fails non-recoverably (it throws `MsalUiRequiredException` because the refresh token is gone or revoked), the MSAL account record still exists, so `isSignedIn()` stays `true`. The app kept showing the cached task list while every API call returned 401, and the failure was swallowed silently with no user-facing signal. Confirmed on a device via logcat:

```
AuthManager: MsalUiRequiredException: No refresh token was found.
AuthInterceptor: Token refresh failed
SyncCoordinator: Refresh tasks/labels failed: HTTP 401
UserRepository: Failed to fetch profile: 401
```

## Approach

- `AuthManager` exposes a new `sessionExpired: StateFlow<Boolean>`, set when a silent refresh fails with `MsalUiRequiredException` (and the stale token is cleared). It is reset on any successful token acquisition / interactive sign-in and on sign-out.
- The OkHttp `Authenticator` now forces a real token refresh on 401 (`getAccessToken(forceRefresh = true)`), so a token that is still locally unexpired but rejected server-side can no longer mask the expiry and skip the silent-refresh path.
- A new `AuthErrorBanner` composable renders above the existing sync banner when `sessionExpired` is true. Its "Sign in" action re-launches interactive MSAL auth, which is the only real recovery for this state.
- Once the session recovers (expired -> active), the task list auto-refreshes so the user isn't left staring at the stale cache the failed syncs left behind.

## Notes for reviewers

- The banner is intentionally sticky: it clears only on successful re-auth or sign-out, so cancelling the sign-in prompt keeps it visible.
- Detection is keyed specifically to `MsalUiRequiredException` to avoid false positives from transient network/service MSAL errors.
- `AuthTokenProvider.getAccessToken` gained a defaulted `forceRefresh` parameter; the only other caller (`WebSocketManager`) keeps the default behavior.
- Verified with `:app:compileDebugKotlin` (build successful).