### PR TITLE
ci: run Playwright E2E only on push to main

### DIFF
--- a/.github/workflows/frontend-build.yml
+++ b/.github/workflows/frontend-build.yml
@@ -28,9 +28,6 @@ jobs:
     - name: Install dependencies
       run: yarn install --frozen-lockfile
       working-directory: frontend
-    - name: Install Playwright Browsers
-      run: npx playwright install --with-deps chromium
-      working-directory: frontend
     - name: Lint
       run: yarn lint
       working-directory: frontend
@@ -40,12 +37,20 @@ jobs:
     - name: Build (Vite)
       run: yarn build
       working-directory: frontend
+    - name: Run unit tests
+      run: yarn test
+      working-directory: frontend
+    - name: Install Playwright Browsers
+      if: github.event_name == 'push'
+      run: npx playwright install --with-deps chromium
+      working-directory: frontend
     - name: Run Playwright tests
+      if: github.event_name == 'push'
       run: yarn test:e2e
       working-directory: frontend
     - uses: actions/upload-artifact@v4
-      if: always()
+      if: github.event_name == 'push' && always()
       with:
         name: playwright-report
-        path: playwright-report/
+        path: frontend/playwright-report/
         retention-days: 30


### PR DESCRIPTION
## Motivation

Playwright browser install + E2E tests made PR validation slow. This moves the slow E2E work out of the pull_request path so PR feedback is fast, while still running full E2E after merge.

## Changes

Kept a **single** `frontend-build.yml` (no second workflow file) and gated the slow steps with `if: github.event_name == 'push'`:

- **PR validation** now runs only fast checks: `yarn install --frozen-lockfile` → `yarn lint` → `yarn tsc` → `yarn build` → `yarn test` (Jest unit tests).
- **Push to main** additionally runs: `npx playwright install --with-deps chromium` → `yarn test:e2e` → upload `playwright-report` artifact.

Also:
- **Added the previously-missing `yarn test` step** (quick Jest unit tests) — the workflow never ran these before.
- **Fixed the artifact path** from `playwright-report/` (repo root) to `frontend/playwright-report/`, where Playwright actually writes the report.

## Verification

Ran the PR-path checks locally in `frontend/`, all passing:
- `yarn install --frozen-lockfile` ✅
- `yarn lint` ✅
- `yarn tsc` ✅
- `yarn build` ✅
- `yarn test` ✅ (8 suites, 76 tests passed)

Grepped the repo for `playwright`, `test:e2e`, and `--with-deps`: no other workflow, script, or Dockerfile runs Playwright on `pull_request`.