### PR TITLE
Make settings server card stretch full width on Android

### DIFF
--- a/android/app/src/main/java/com/dkhalife/tasks/ui/screen/SettingsScreen.kt
+++ b/android/app/src/main/java/com/dkhalife/tasks/ui/screen/SettingsScreen.kt
@@ -540,6 +540,7 @@ private fun SettingsCard(
     content: @Composable ColumnScope.() -> Unit
 ) {
     Card(
+        modifier = Modifier.fillMaxWidth(),
         shape = RoundedCornerShape(16.dp),
         colors = CardDefaults.cardColors(
             containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.4f)


### PR DESCRIPTION
## Why

In the Android settings screen, the first section (Server/host) rendered with a narrower outlined rounded rectangle than every other section. This looked inconsistent because the card hugged its short text content instead of spanning the screen.

## Approach

The shared `SettingsCard` composable previously had no width modifier, so its `Card` sized to its content. Sections like Theme and Task grouping contain full-width rows (`SingleChoiceSegmentedButtonRow` with `fillMaxWidth`), which forced those cards wide, while the Server section only holds a short text endpoint and stayed narrow.

Adding `Modifier.fillMaxWidth()` to `SettingsCard` makes all sections stretch the full width uniformly, fixing the visual without touching individual section content.