### PR TITLE
Fix session-expired banner re-auth in MSAL single-account mode

### DIFF
--- a/android/app/src/main/java/com/dkhalife/tasks/auth/AuthManager.kt
+++ b/android/app/src/main/java/com/dkhalife/tasks/auth/AuthManager.kt
@@ -144,7 +144,7 @@ class AuthManager @Inject constructor(
             return
         }
 
-        val params = AcquireTokenParameters.Builder()
+        val builder = AcquireTokenParameters.Builder()
             .startAuthorizationFromActivity(activity)
             .withScopes(REQUIRED_SCOPES)
             .withCallback(object : AuthenticationCallback {
@@ -162,9 +162,13 @@ class AuthManager @Inject constructor(
                     callback.onCancel()
                 }
             })
-            .build()
 
-        app.acquireToken(params)
+        // In single-account mode an interactive acquireToken while an account is already persisted
+        // (re-authenticating after a session expired) must target that same account, otherwise MSAL
+        // rejects it with CURRENT_ACCOUNT_MISMATCH before any sign-in UI is shown.
+        currentAccount?.let { builder.forAccount(it) }
+
+        app.acquireToken(builder.build())
     }
 
     fun signOut(callback: ISingleAccountPublicClientApplication.SignOutCallback) {


### PR DESCRIPTION
## Why

When a non-recoverable auth failure occurs (e.g. the refresh token is revoked after the account's password is changed on another device), the app shows the session-expired `AuthErrorBanner`. Tapping its "Sign In" button did nothing: no sign-in UI, no error.

## Root cause

The banner reuses `AuthManager.signIn`, which builds an `AcquireTokenParameters` with neither an account nor a login hint. In MSAL single-account mode, interactive `acquireToken` rejects such a request with `CURRENT_ACCOUNT_MISMATCH` ("The signed in account does not match with the provided account") whenever an account is already persisted, before any UI is shown. The full-screen sign-in worked only because no account exists in that state. The error was also swallowed because the banner never renders `errorMessage`, so the failure was invisible.

Despite the misleading message, there is no second account involved: the request simply targeted nobody while one account was signed in.

## Fix

Target the existing account via `forAccount` when one is present:

```kotlin
currentAccount?.let { builder.forAccount(it) }
```

This keeps a single `signIn` flow that handles both cases:

- No persisted account (fresh sign-in / signed out): unchanged interactive sign-in.
- Account present but session expired (revoked refresh token after a password change): interactive re-auth targeted at that same account, so AAD presents the sign-in page for it and the user enters the new password.

On success, the existing token cache reset clears `sessionExpired`, and the task list already re-pulls on that transition.

## Notes

- No forced `Prompt.LOGIN`: a valid device SSO session should still be reusable; AAD challenges for the new password on its own when the session is stale.
- No PII logging added.

Verified with `./gradlew :app:compileDebugKotlin`.