### PR TITLE
Add rate limiting to task API routes

### DIFF
--- a/apiserver/internal/apis/task.go
+++ b/apiserver/internal/apis/task.go
@@ -13,6 +13,7 @@ import (
 	auth "dkhalife.com/tasks/core/internal/utils/auth"
 	middleware "dkhalife.com/tasks/core/internal/utils/middleware"
 	"github.com/gin-gonic/gin"
+	limiter "github.com/ulule/limiter/v3"
 )
 
 type TasksAPIHandler struct {
@@ -297,9 +298,9 @@ func (h *TasksAPIHandler) GetTaskHistory(c *gin.Context) {
 	c.JSON(status, response)
 }
 
-func TaskRoutes(router *gin.Engine, h *TasksAPIHandler, auth *authMW.AuthMiddleware) {
+func TaskRoutes(router *gin.Engine, h *TasksAPIHandler, auth *authMW.AuthMiddleware, limiter *limiter.Limiter) {
 	tasksRoutes := router.Group("api/v1/tasks")
-	tasksRoutes.Use(auth.MiddlewareFunc(), middleware.DeletionGuardMiddleware())
+	tasksRoutes.Use(auth.MiddlewareFunc(), middleware.RateLimitMiddleware(limiter), middleware.DeletionGuardMiddleware())
 	{
 		tasksRoutes.GET("/", authMW.ScopeMiddleware(models.ApiTokenScopeTaskRead), h.getTasks)
 		tasksRoutes.GET("/due", authMW.ScopeMiddleware(models.ApiTokenScopeTaskRead), h.getTasksDueBefore)


### PR DESCRIPTION
## Problem

The `api/v1/tasks` route group in `apiserver/internal/apis/task.go` was registered with only `auth.MiddlewareFunc()` and `middleware.DeletionGuardMiddleware()` — it had **no IP-based rate limiting**, unlike the user (`user.go`), log (`log.go`), and backend route groups. This meant endpoints such as `GET /api/v1/tasks/search?q=` could be queried at unlimited volume by any authenticated user, enabling brute-force/enumeration and abuse.

## Fix

Applied the existing IP-based rate limiter to the tasks route group, matching the pattern used by `UserRoutes`:

- Added a `limiter *limiter.Limiter` parameter to `TaskRoutes` (imported `limiter "github.com/ulule/limiter/v3"`).
- Added `middleware.RateLimitMiddleware(limiter)` to `tasksRoutes.Use(...)`.

The limiter is already provided in `main.go` via `fx.Provide(utils.NewRateLimiter)`, and `TaskRoutes` is wired through `fx.Invoke(apis.TaskRoutes, ...)`, so fx injects the new parameter automatically.

## Validation

- `go build ./...` — passes
- `go test ./...` — passes
- `golangci-lint run` — passes

No direct test call sites construct `TaskRoutes`, so no test updates were needed.