### PR TITLE
Return 404 instead of 403 for non-owned tasks to remove existence oracle

### DIFF
--- a/apiserver/internal/services/tasks/task.go
+++ b/apiserver/internal/services/tasks/task.go
@@ -146,10 +146,8 @@ func (s *TaskService) GetTask(ctx context.Context, userID, taskID int) (int, int
 	}
 
 	if userID != task.CreatedBy {
-		telemetry.TrackWarning(ctx, "task_forbidden", "task-service", "User not allowed to view task", nil)
-		return http.StatusForbidden, gin.H{
-			"error": "You are not allowed to view this task",
-		}
+		telemetry.TrackWarning(ctx, "task_not_found", "task-service", "User not allowed to view task", nil)
+		return http.StatusNotFound, gin.H{"error": "Task not found"}
 	}
 
 	return http.StatusOK, gin.H{
@@ -293,10 +291,8 @@ func (s *TaskService) EditTask(ctx context.Context, userID int, req models.Updat
 	}
 
 	if userID != oldTask.CreatedBy {
-		telemetry.TrackWarning(ctx, "task_forbidden", "task-service", "User not allowed to edit task", nil)
-		return http.StatusForbidden, gin.H{
-			"error": "You are not allowed to edit this task",
-		}
+		telemetry.TrackWarning(ctx, "task_not_found", "task-service", "User not allowed to edit task", nil)
+		return http.StatusNotFound, gin.H{"error": "Task not found"}
 	}
 
 	if err := s.l.AssignLabelsToTask(ctx, taskId, userID, req.Labels); err != nil {
@@ -346,10 +342,8 @@ func (s *TaskService) DeleteTask(ctx context.Context, userID, taskID int) (int, 
 	log := logging.FromContext(ctx)
 
 	if err := s.t.IsTaskOwner(ctx, taskID, userID); err != nil {
-		telemetry.TrackWarning(ctx, "task_forbidden", "task-service", "User not allowed to delete task", nil)
-		return http.StatusForbidden, gin.H{
-			"error": "You are not allowed to delete this task",
-		}
+		telemetry.TrackWarning(ctx, "task_not_found", "task-service", "User not allowed to delete task", nil)
+		return http.StatusNotFound, gin.H{"error": "Task not found"}
 	}
 
 	if err := s.t.DeleteTask(ctx, taskID); err != nil {
@@ -385,10 +379,8 @@ func (s *TaskService) SkipTask(ctx context.Context, userID, taskID int) (int, in
 	}
 
 	if userID != task.CreatedBy {
-		telemetry.TrackWarning(ctx, "task_forbidden", "task-service", "User not allowed to skip task", nil)
-		return http.StatusForbidden, gin.H{
-			"error": "You are not allowed to skip this task",
-		}
+		telemetry.TrackWarning(ctx, "task_not_found", "task-service", "User not allowed to skip task", nil)
+		return http.StatusNotFound, gin.H{"error": "Task not found"}
 	}
 
 	if task.NextDueDate == nil {
@@ -455,10 +447,8 @@ func (s *TaskService) UpdateDueDate(ctx context.Context, userID, taskID int, req
 	}
 
 	if userID != task.CreatedBy {
-		telemetry.TrackWarning(ctx, "task_forbidden", "task-service", "User not allowed to update due date", nil)
-		return http.StatusForbidden, gin.H{
-			"error": "You are not allowed to update this task",
-		}
+		telemetry.TrackWarning(ctx, "task_not_found", "task-service", "User not allowed to update due date", nil)
+		return http.StatusNotFound, gin.H{"error": "Task not found"}
 	}
 
 	if req.DueDate != "" {
@@ -514,10 +504,8 @@ func (s *TaskService) CompleteTask(ctx context.Context, userID, taskID int, endR
 	}
 
 	if userID != task.CreatedBy {
-		telemetry.TrackWarning(ctx, "task_forbidden", "task-service", "User not allowed to complete task", nil)
-		return http.StatusForbidden, gin.H{
-			"error": "You are not allowed to complete this task",
-		}
+		telemetry.TrackWarning(ctx, "task_not_found", "task-service", "User not allowed to complete task", nil)
+		return http.StatusNotFound, gin.H{"error": "Task not found"}
 	}
 
 	var completedDate time.Time = time.Now().UTC()
@@ -581,10 +569,8 @@ func (s *TaskService) RevertAction(ctx context.Context, userID, taskID, historyI
 	}
 
 	if userID != task.CreatedBy {
-		telemetry.TrackWarning(ctx, "task_forbidden", "task-service", "User not allowed to revert task action", nil)
-		return http.StatusForbidden, gin.H{
-			"error": "You are not allowed to update this task",
-		}
+		telemetry.TrackWarning(ctx, "task_not_found", "task-service", "User not allowed to revert task action", nil)
+		return http.StatusNotFound, gin.H{"error": "Task not found"}
 	}
 
 	if err := s.t.RevertActivity(ctx, taskID, historyID); err != nil {
@@ -629,10 +615,8 @@ func (s *TaskService) GetTaskHistory(ctx context.Context, userID, taskID int) (i
 	log := logging.FromContext(ctx)
 
 	if err := s.t.IsTaskOwner(ctx, taskID, userID); err != nil {
-		telemetry.TrackWarning(ctx, "task_forbidden", "task-service", "User not allowed to view task history", nil)
-		return http.StatusForbidden, gin.H{
-			"error": "You are not allowed to view this task's history",
-		}
+		telemetry.TrackWarning(ctx, "task_not_found", "task-service", "User not allowed to view task history", nil)
+		return http.StatusNotFound, gin.H{"error": "Task not found"}
 	}
 
 	TaskHistory, err := s.t.GetTaskHistory(ctx, taskID)

--- a/apiserver/internal/services/tasks/task.go
+++ b/apiserver/internal/services/tasks/task.go
@@ -342,8 +342,15 @@ func (s *TaskService) DeleteTask(ctx context.Context, userID, taskID int) (int, 
 	log := logging.FromContext(ctx)
 
 	if err := s.t.IsTaskOwner(ctx, taskID, userID); err != nil {
-		telemetry.TrackWarning(ctx, "task_not_found", "task-service", "User not allowed to delete task", nil)
-		return http.StatusNotFound, gin.H{"error": "Task not found"}
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			telemetry.TrackWarning(ctx, "task_not_found", "task-service", "User not allowed to delete task", nil)
+			return http.StatusNotFound, gin.H{"error": "Task not found"}
+		}
+		log.Errorf("error checking task ownership: %s", err.Error())
+		telemetry.TrackError(ctx, "task_delete_failed", "task-service", err, nil)
+		return http.StatusInternalServerError, gin.H{
+			"error": "Error deleting task",
+		}
 	}
 
 	if err := s.t.DeleteTask(ctx, taskID); err != nil {
@@ -615,8 +622,15 @@ func (s *TaskService) GetTaskHistory(ctx context.Context, userID, taskID int) (i
 	log := logging.FromContext(ctx)
 
 	if err := s.t.IsTaskOwner(ctx, taskID, userID); err != nil {
-		telemetry.TrackWarning(ctx, "task_not_found", "task-service", "User not allowed to view task history", nil)
-		return http.StatusNotFound, gin.H{"error": "Task not found"}
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			telemetry.TrackWarning(ctx, "task_not_found", "task-service", "User not allowed to view task history", nil)
+			return http.StatusNotFound, gin.H{"error": "Task not found"}
+		}
+		log.Errorf("error checking task ownership: %s", err.Error())
+		telemetry.TrackError(ctx, "task_history_failed", "task-service", err, nil)
+		return http.StatusInternalServerError, gin.H{
+			"error": "Error getting task history",
+		}
 	}
 
 	TaskHistory, err := s.t.GetTaskHistory(ctx, taskID)


### PR DESCRIPTION
## Problem

Several handlers in `apiserver/internal/services/tasks/task.go` distinguished "task does not exist" (HTTP 404) from "task exists but belongs to another user" (HTTP 403). This difference acted as an **existence oracle**: an authenticated attacker could enumerate which global task IDs exist by observing whether a given ID returned 404 (missing) vs 403 (exists but not owned), leaking information about other users' data volume and IDs.

## Change

Every handler that previously returned `403 Forbidden` on an ownership mismatch now returns `404 Not Found` with the exact same body used by the genuine not-found branch (`gin.H{"error": "Task not found"}`). A caller can no longer tell whether a task ID exists when it is not theirs.

Affected handlers:
- `GetTask`
- `EditTask`
- `SkipTask`
- `UpdateDueDate`
- `CompleteTask`
- `RevertAction`
- `DeleteTask` (via `IsTaskOwner`)
- `GetTaskHistory` (via `IsTaskOwner`)

The `IsTaskOwner` paths already could not distinguish not-found from not-owned, so 404 is the correct unified response there as well.

`telemetry.TrackWarning` calls are retained, with the event key updated from `task_forbidden` to `task_not_found` to reflect the new response. Genuine internal/server errors (500) remain distinct.

## Validation
- `go build ./...` — passes
- `go test ./...` — passes (no existing tests asserted 403 for ownership mismatch)
- `golangci-lint run` — passes

No `.agents/` documentation referenced the prior 403 behavior, so no docs required updating.