### PR TITLE
Reject insecure CORS wildcard + credentials configuration

### DIFF
--- a/apiserver/config/config.go
+++ b/apiserver/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"os"
 	"time"
 
@@ -97,4 +98,22 @@ func LoadConfig(configFile string) *Config {
 	}
 
 	return &config
+}
+
+// ValidateCorsConfig rejects insecure CORS configurations. Allowing credentials
+// together with a wildcard origin would let any website make credentialed
+// cross-origin requests and read the responses, so the server must refuse to
+// start in that case.
+func ValidateCorsConfig(cfg *Config) error {
+	if !cfg.Server.AllowCorsCredentials {
+		return nil
+	}
+
+	for _, origin := range cfg.Server.AllowedOrigins {
+		if origin == "*" {
+			return fmt.Errorf("insecure CORS configuration: allow_cors_credentials cannot be enabled together with a wildcard ('*') entry in allowed_origins; specify explicit origins instead")
+		}
+	}
+
+	return nil
 }

--- a/apiserver/config/config_test.go
+++ b/apiserver/config/config_test.go
@@ -229,3 +229,61 @@ server:
 	assert.Equal(t, "testpass", cfg.Database.Password)
 	assert.Equal(t, true, cfg.Database.Migration)
 }
+
+func TestValidateCorsConfig(t *testing.T) {
+	cases := []struct {
+		name        string
+		origins     []string
+		credentials bool
+		wantErr     bool
+	}{
+		{
+			name:        "wildcard with credentials is rejected",
+			origins:     []string{"*"},
+			credentials: true,
+			wantErr:     true,
+		},
+		{
+			name:        "wildcard among explicit origins with credentials is rejected",
+			origins:     []string{"https://app.example.com", "*"},
+			credentials: true,
+			wantErr:     true,
+		},
+		{
+			name:        "wildcard without credentials is allowed",
+			origins:     []string{"*"},
+			credentials: false,
+			wantErr:     false,
+		},
+		{
+			name:        "explicit origins with credentials is allowed",
+			origins:     []string{"https://app.example.com"},
+			credentials: true,
+			wantErr:     false,
+		},
+		{
+			name:        "empty list is allowed",
+			origins:     nil,
+			credentials: true,
+			wantErr:     false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &Config{
+				Server: ServerConfig{
+					AllowedOrigins:       tc.origins,
+					AllowCorsCredentials: tc.credentials,
+				},
+			}
+
+			err := ValidateCorsConfig(cfg)
+			if tc.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/apiserver/main.go
+++ b/apiserver/main.go
@@ -43,6 +43,9 @@ func main() {
 	flag.Parse()
 
 	cfg := config.LoadConfig(*cfgFile)
+	if err := config.ValidateCorsConfig(cfg); err != nil {
+		log.Fatal(err)
+	}
 	level, err := zapcore.ParseLevel(cfg.Server.LogLevel)
 	if err != nil {
 		level = zapcore.WarnLevel


### PR DESCRIPTION
## Problem

In `apiserver/main.go` (`newServer`), CORS is configured from `cfg.Server.AllowedOrigins` and `cfg.Server.AllowCorsCredentials`. While the currently deployed config uses an explicit allow-list (safe), the combination is a config footgun: setting `AllowedOrigins` to include `"*"` together with `AllowCorsCredentials=true` would let **any** website make credentialed cross-origin requests and read the responses — directly enabling exfiltration of a logged-in victim's task names. `gin-contrib/cors` may panic or silently misbehave in this combination.

## Fix

Added a fail-fast startup guard:

- New testable helper `config.ValidateCorsConfig(cfg *Config) error` in `apiserver/config/config.go`. It returns a clear, descriptive error when `AllowCorsCredentials == true` **and** `AllowedOrigins` contains a `"*"` wildcard entry.
- `main()` calls `ValidateCorsConfig` right after `LoadConfig` and `log.Fatal`s on error, so the server refuses to start with an exploitable config instead of serving it.

All other behavior is unchanged — CORS is still only enabled when `len(AllowedOrigins) > 0`, and explicit origins with credentials continue to work.

## Tests

Added `TestValidateCorsConfig` covering:
- wildcard + credentials → error
- wildcard among explicit origins + credentials → error
- wildcard without credentials → ok
- explicit origins + credentials → ok
- empty list → ok

Validated with `go build ./...`, `go test ./...`, and `golangci-lint run` — all pass.