### PR TITLE
Restrict WebSocket CheckOrigin to configured allowed origins

### DIFF
--- a/apiserver/internal/services/users/user_test.go
+++ b/apiserver/internal/services/users/user_test.go
@@ -39,7 +39,7 @@ func (s *UserServiceTestSuite) SetupTest() {
 	authMiddleware, _ := authMW.NewAuthMiddleware(&config.Config{}, s.repo, nil)
 	taskRepo := tRepo.NewTaskRepository(s.DB, cfg)
 	labelRepo := lRepo.NewLabelRepository(s.DB, cfg)
-	s.wsServer = ws.NewWSServer(authMiddleware, taskRepo, labelRepo, s.repo)
+	s.wsServer = ws.NewWSServer(cfg, authMiddleware, taskRepo, labelRepo, s.repo)
 	s.service = NewUserService(s.repo, s.wsServer)
 }
 

--- a/apiserver/internal/ws/server.go
+++ b/apiserver/internal/ws/server.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"time"
 
+	"dkhalife.com/tasks/core/config"
 	"dkhalife.com/tasks/core/internal/models"
 	lRepo "dkhalife.com/tasks/core/internal/repos/label"
 	tRepo "dkhalife.com/tasks/core/internal/repos/task"
@@ -44,12 +45,12 @@ type WSServer struct {
 type messageHandler func(ctx context.Context, userID int, msg WSMessage) *WSResponse
 
 // NewWSServer creates a new websocket server instance.
-func NewWSServer(authMiddleware *authMW.AuthMiddleware, tRepo *tRepo.TaskRepository, lRepo *lRepo.LabelRepository, uRepo uRepo.IUserRepo) *WSServer {
+func NewWSServer(cfg *config.Config, authMiddleware *authMW.AuthMiddleware, tRepo *tRepo.TaskRepository, lRepo *lRepo.LabelRepository, uRepo uRepo.IUserRepo) *WSServer {
 	return &WSServer{
 		upgrader: websocket.Upgrader{
 			ReadBufferSize:  1024,
 			WriteBufferSize: 1024,
-			CheckOrigin:     func(r *http.Request) bool { return true },
+			CheckOrigin:     checkOrigin(cfg.Server.AllowedOrigins),
 		},
 		connections:     make(map[*websocket.Conn]*connection),
 		userConnections: make(map[int]map[*websocket.Conn]*connection),
@@ -60,6 +61,31 @@ func NewWSServer(authMiddleware *authMW.AuthMiddleware, tRepo *tRepo.TaskReposit
 		tRepo:           tRepo,
 		lRepo:           lRepo,
 		uRepo:           uRepo,
+	}
+}
+
+// checkOrigin builds a CheckOrigin function restricting WebSocket upgrades to the
+// configured allowed origins, mirroring the HTTP CORS allow-list. When the list is
+// empty the check stays permissive to preserve same-origin and local/dev deployments.
+// Requests without an Origin header (non-browser clients) are always allowed.
+func checkOrigin(allowedOrigins []string) func(r *http.Request) bool {
+	return func(r *http.Request) bool {
+		if len(allowedOrigins) == 0 {
+			return true
+		}
+
+		origin := r.Header.Get("Origin")
+		if origin == "" {
+			return true
+		}
+
+		for _, allowed := range allowedOrigins {
+			if origin == allowed {
+				return true
+			}
+		}
+
+		return false
 	}
 }
 

--- a/apiserver/internal/ws/server_test.go
+++ b/apiserver/internal/ws/server_test.go
@@ -53,7 +53,7 @@ func (s *WSServerTestSuite) SetupTest() {
 	authMiddleware, err := authMW.NewAuthMiddleware(cfg, mockRepo, nil)
 	s.Require().NoError(err)
 
-	s.server = NewWSServer(authMiddleware, nil, nil, mockRepo)
+	s.server = NewWSServer(cfg, authMiddleware, nil, nil, mockRepo)
 	s.router = gin.New()
 	s.router.GET("/ws", s.server.HandleConnection)
 }
@@ -161,6 +161,27 @@ func (s *WSServerTestSuite) TestRegisterHandler_DuplicatePanics() {
 
 	s.server.RegisterHandler("dup", handler)
 	s.Panics(func() { s.server.RegisterHandler("dup", handler) })
+}
+
+func (s *WSServerTestSuite) TestCheckOrigin() {
+	newRequest := func(origin string) *http.Request {
+		r := httptest.NewRequest(http.MethodGet, "/ws", nil)
+		if origin != "" {
+			r.Header.Set("Origin", origin)
+		}
+		return r
+	}
+
+	allowed := []string{"https://app.example.com", "https://admin.example.com"}
+
+	check := checkOrigin(allowed)
+	s.True(check(newRequest("https://app.example.com")), "allowed origin should be accepted")
+	s.False(check(newRequest("https://evil.example.com")), "disallowed origin should be rejected")
+	s.True(check(newRequest("")), "missing origin should be accepted")
+
+	permissive := checkOrigin(nil)
+	s.True(permissive(newRequest("https://anything.example.com")), "empty allow-list should be permissive")
+	s.True(permissive(newRequest("")), "empty allow-list with no origin should be permissive")
 }
 
 func (s *WSServerTestSuite) TestHandleMessageRoutesResponse() {


### PR DESCRIPTION
## Problem

The websocket upgrader in `apiserver/internal/ws/server.go` was created with a permissive origin check:

```go
CheckOrigin: func(r *http.Request) bool { return true }
```

This accepted WebSocket upgrade requests from **any** origin. While the risk is mitigated today because WS auth uses a bearer token passed in the `Sec-WebSocket-Protocol` header (not a cookie), accepting all origins is unnecessary attack surface and should be tightened as defense-in-depth — consistent with the HTTP CORS allow-list (`cfg.Server.AllowedOrigins`).

## Change

- Inject `*config.Config` into `NewWSServer` (fx already supplies it via `fx.Supply(cfg)`).
- Add a `checkOrigin` helper that restricts upgrades to `cfg.Server.AllowedOrigins` — the **same** allow-list used by the HTTP CORS setup in `main.go`, so API and WS share one source of truth.
- Origin handling mirrors `main.go`'s CORS gating:
  - Allow when the `Origin` header exactly matches a configured entry.
  - Stay permissive when `AllowedOrigins` is empty (preserves local/dev and same-origin deployments where the list is unset).
  - Allow requests with no `Origin` header (non-browser clients).

## Validation

- `go build ./...` ✅
- `go test ./...` ✅ — added a `TestCheckOrigin` unit test covering allowed origin, disallowed origin (non-empty list), empty list (permissive), and missing Origin header. Updated `NewWSServer` call sites in `server_test.go` and `user_test.go` to pass the config.
- `golangci-lint run` ✅