### PR TITLE
Anchor task context menu to long-press position

### DIFF
--- a/android/app/src/main/java/com/dkhalife/tasks/ui/components/TaskItem.kt
+++ b/android/app/src/main/java/com/dkhalife/tasks/ui/components/TaskItem.kt
@@ -45,7 +45,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.input.pointer.pointerInput
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.CustomAccessibilityAction
@@ -90,7 +89,6 @@ fun TaskItem(
 
     var showDeleteConfirmation by remember { mutableStateOf(false) }
     var showContextMenu by remember { mutableStateOf(false) }
-    val density = LocalDensity.current
     var contextMenuOffset by remember { mutableStateOf(DpOffset.Zero) }
 
     if (showDeleteConfirmation) {
@@ -149,12 +147,10 @@ fun TaskItem(
                     .pointerInput(Unit) {
                         awaitEachGesture {
                             val down = awaitFirstDown(requireUnconsumed = false)
-                            contextMenuOffset = with(density) {
-                                DpOffset(
-                                    down.position.x.toDp(),
-                                    (down.position.y - size.height).toDp()
-                                )
-                            }
+                            contextMenuOffset = DpOffset(
+                                down.position.x.toDp(),
+                                (down.position.y - size.height).toDp()
+                            )
                         }
                     }
                     .combinedClickable(

--- a/android/app/src/main/java/com/dkhalife/tasks/ui/components/TaskItem.kt
+++ b/android/app/src/main/java/com/dkhalife/tasks/ui/components/TaskItem.kt
@@ -2,6 +2,8 @@ package com.dkhalife.tasks.ui.components
 
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -42,12 +44,15 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.CustomAccessibilityAction
 import androidx.compose.ui.semantics.customActions
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import com.dkhalife.tasks.R
 import com.dkhalife.tasks.data.SwipeAction
@@ -85,6 +90,8 @@ fun TaskItem(
 
     var showDeleteConfirmation by remember { mutableStateOf(false) }
     var showContextMenu by remember { mutableStateOf(false) }
+    val density = LocalDensity.current
+    var contextMenuOffset by remember { mutableStateOf(DpOffset.Zero) }
 
     if (showDeleteConfirmation) {
         AlertDialog(
@@ -139,6 +146,17 @@ fun TaskItem(
                 elevation = CardDefaults.cardElevation(defaultElevation = 1.dp),
                 modifier = Modifier
                     .fillMaxWidth()
+                    .pointerInput(Unit) {
+                        awaitEachGesture {
+                            val down = awaitFirstDown(requireUnconsumed = false)
+                            contextMenuOffset = with(density) {
+                                DpOffset(
+                                    down.position.x.toDp(),
+                                    (down.position.y - size.height).toDp()
+                                )
+                            }
+                        }
+                    }
                     .combinedClickable(
                         onClick = onClick,
                         onLongClick = {
@@ -200,7 +218,8 @@ fun TaskItem(
 
             DropdownMenu(
                 expanded = showContextMenu,
-                onDismissRequest = { showContextMenu = false }
+                onDismissRequest = { showContextMenu = false },
+                offset = contextMenuOffset
             ) {
                 DropdownMenuItem(
                     text = { Text(completeLabel) },


### PR DESCRIPTION
## Why

When long-pressing a task in the Android task list, the context menu opened anchored to the item's bottom-left corner regardless of where the user actually touched. This feels disconnected from the gesture, especially on wide items where the finger is far from the menu's origin.

## What changed

The flyout now opens at the finger's touch point:

- A `pointerInput` on the task card records the initial touch position and converts it to a `DpOffset`.
- That offset is passed to the Material3 `DropdownMenu`. Because the position provider anchors the vertical offset to the item's bottom, the item height is subtracted so the menu's top-left lands at the finger rather than below the whole card.

## Edge cases

Horizontal overflow is handled for free by Material3's built-in `DropdownMenuPositionProvider`, which clamps the popup within the window. Since task cards span nearly the full width, when the finger-based position would overflow on the right, the provider falls back to its display-right placement so the menu's right edge aligns with the screen border.

The change is confined to `TaskItem.kt` and compiles cleanly (`:app:compileDebugKotlin` passes).