### PR TITLE
Fail fast when auth is disabled in production

### DIFF
--- a/apiserver/config/config.dev.yaml
+++ b/apiserver/config/config.dev.yaml
@@ -12,6 +12,7 @@ server:
   serve_frontend: false
   registration: true
   log_level: "debug"
+  allow_insecure_no_auth: true
   allowed_origins:
     - http://localhost:5173
   allow_cors_credentials: true

--- a/apiserver/config/config.go
+++ b/apiserver/config/config.go
@@ -46,6 +46,7 @@ type ServerConfig struct {
 	AllowedOrigins       []string      `mapstructure:"allowed_origins" yaml:"allowed_origins"`
 	AllowCorsCredentials bool          `mapstructure:"allow_cors_credentials" yaml:"allow_cors_credentials"`
 	SessionDuration      time.Duration `mapstructure:"session_duration" yaml:"session_duration" default:"720h"`
+	AllowInsecureNoAuth  bool          `mapstructure:"allow_insecure_no_auth" yaml:"allow_insecure_no_auth"`
 }
 
 type SchedulerConfig struct {
@@ -78,6 +79,7 @@ func LoadConfig(configFile string) *Config {
 	_ = viper.BindEnv("entra.audience", "TW_ENTRA_AUDIENCE")
 	_ = viper.BindEnv("entra.issuer", "TW_ENTRA_ISSUER")
 	_ = viper.BindEnv("server.session_duration", "TW_SESSION_DURATION")
+	_ = viper.BindEnv("server.allow_insecure_no_auth", "TW_ALLOW_INSECURE_NO_AUTH")
 	_ = viper.BindEnv("database.type", "TW_DATABASE_TYPE")
 	_ = viper.BindEnv("database.host", "TW_DATABASE_HOST")
 	_ = viper.BindEnv("database.port", "TW_DATABASE_PORT")

--- a/apiserver/internal/middleware/auth/auth.go
+++ b/apiserver/internal/middleware/auth/auth.go
@@ -54,7 +54,7 @@ func NewAuthMiddleware(cfg *config.Config, userRepo uRepo.IUserRepo, sessionRepo
 		}
 
 		if cfg.Server.AllowInsecureNoAuth {
-			logging.DefaultLogger().Warn("SECURITY WARNING: authentication is disabled and the insecure no-auth bypass is explicitly enabled (server.allow_insecure_no_auth=true). Every request resolves to a single shared dev user. Never use this in production.")
+			logging.DefaultLogger().Error("SECURITY WARNING: authentication is disabled and the insecure no-auth bypass is explicitly enabled (server.allow_insecure_no_auth=true). Every request resolves to a single shared dev user. Never use this in production.")
 		}
 
 		return m, nil

--- a/apiserver/internal/middleware/auth/auth.go
+++ b/apiserver/internal/middleware/auth/auth.go
@@ -13,6 +13,7 @@ import (
 	"dkhalife.com/tasks/core/internal/models"
 	sRepo "dkhalife.com/tasks/core/internal/repos/session"
 	uRepo "dkhalife.com/tasks/core/internal/repos/user"
+	"dkhalife.com/tasks/core/internal/services/logging"
 	"dkhalife.com/tasks/core/internal/telemetry"
 	authUtils "dkhalife.com/tasks/core/internal/utils/auth"
 	oidc "github.com/coreos/go-oidc/v3/oidc"
@@ -48,6 +49,14 @@ func NewAuthMiddleware(cfg *config.Config, userRepo uRepo.IUserRepo, sessionRepo
 	}
 
 	if !cfg.Entra.Enabled {
+		if cfg.Server.HostName != "" && !cfg.Server.AllowInsecureNoAuth {
+			return nil, fmt.Errorf("authentication is disabled (entra.enabled=false) while server.host_name is set (%q); refusing to start in a production-like configuration. Set server.allow_insecure_no_auth=true (env TW_ALLOW_INSECURE_NO_AUTH=true) to explicitly opt in to the insecure dev bypass", cfg.Server.HostName)
+		}
+
+		if cfg.Server.AllowInsecureNoAuth {
+			logging.DefaultLogger().Warn("SECURITY WARNING: authentication is disabled and the insecure no-auth bypass is explicitly enabled (server.allow_insecure_no_auth=true). Every request resolves to a single shared dev user. Never use this in production.")
+		}
+
 		return m, nil
 	}
 

--- a/apiserver/internal/middleware/auth/auth_test.go
+++ b/apiserver/internal/middleware/auth/auth_test.go
@@ -1,0 +1,47 @@
+package auth
+
+import (
+	"testing"
+
+	"dkhalife.com/tasks/core/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func newDisabledAuthConfig(hostName string, allowInsecure bool) *config.Config {
+	return &config.Config{
+		Entra: config.EntraConfig{Enabled: false},
+		Server: config.ServerConfig{
+			HostName:            hostName,
+			AllowInsecureNoAuth: allowInsecure,
+		},
+	}
+}
+
+func TestNewAuthMiddleware_DisabledWithHostNameAndNoOptIn_Fails(t *testing.T) {
+	cfg := newDisabledAuthConfig("example.com", false)
+
+	m, err := NewAuthMiddleware(cfg, nil, nil)
+
+	assert.Error(t, err)
+	assert.Nil(t, m)
+}
+
+func TestNewAuthMiddleware_DisabledWithOptIn_Allowed(t *testing.T) {
+	cfg := newDisabledAuthConfig("example.com", true)
+
+	m, err := NewAuthMiddleware(cfg, nil, nil)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, m)
+	assert.False(t, m.enabled)
+}
+
+func TestNewAuthMiddleware_DisabledWithoutHostName_Allowed(t *testing.T) {
+	cfg := newDisabledAuthConfig("", false)
+
+	m, err := NewAuthMiddleware(cfg, nil, nil)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, m)
+	assert.False(t, m.enabled)
+}


### PR DESCRIPTION
## Vulnerability

`AuthMiddleware.authenticate()` falls back to `bypassAuth()` whenever `cfg.Entra.Enabled == false`. `bypassAuth` resolves **every** request — including completely unauthenticated ones — to a single shared dev user (`EnsureUser(ctx, "dev-directory", "dev-object")`).

This is fine for local dev, but if the server is ever deployed with `Entra.Enabled=false`, any anonymous internet user can read/modify that user's data (e.g. `GET /api/v1/tasks/` returns all task names with no token). A single misconfiguration becomes a full data exposure.

## Fix

Add a fail-fast startup guard in `NewAuthMiddleware`. When `Entra.Enabled == false`:

- If a production indicator is present (`server.host_name != ""`) and the new opt-in flag is **not** set, the server refuses to start with a clear fatal error (fx aborts startup since `NewAuthMiddleware` returns an error).
- If the opt-in flag is explicitly set, the bypass is permitted and a loud `SECURITY WARNING` is logged.
- With no host name (pure local dev), the bypass is permitted as before.

`bypassAuth` behavior itself is unchanged.

## New config flag

`server.allow_insecure_no_auth` (bool, default `false`), with env override `TW_ALLOW_INSECURE_NO_AUTH`, consistent with the repo's existing `viper.BindEnv` overrides.

## Keeping the bypass in local dev

`config.dev.yaml` sets `server.allow_insecure_no_auth: true`, so local development continues to work with auth disabled. To run with the bypass elsewhere, set the flag in config or `TW_ALLOW_INSECURE_NO_AUTH=true`.

## Validation

- `go build ./...` ✅
- `go test ./...` ✅ (added tests: disabled + host name + flag false → error; disabled + flag true → allowed; disabled + no host name → allowed)
- `golangci-lint run` ✅