### PR TITLE
Rebrand: rename npm package to @taskwiz/app

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@dkhalife/tasks",
+  "name": "@taskwiz/app",
   "version": "1.0.30",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@dkhalife/tasks",
+      "name": "@taskwiz/app",
       "version": "1.0.30",
       "dependencies": {
         "@azure/msal-browser": "^5.4.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@dkhalife/tasks",
+  "name": "@taskwiz/app",
   "private": true,
   "version": "1.0.30",
   "type": "module",

--- a/frontend/src/contexts/RouterContext.tsx
+++ b/frontend/src/contexts/RouterContext.tsx
@@ -44,7 +44,7 @@ class RouterContextImpl extends React.Component<RouterContextProps, RouterContex
     }
   }
   private getTaskId = (): number => {
-    const match = matchPath<'taskId', string>(
+    const match = matchPath<'/tasks/:taskId'>(
       {
         path: '/tasks/:taskId',
         caseSensitive: true,


### PR DESCRIPTION
Part of the coordinated rebrand from tasks.dkhalife.com to taskwiz.app.

## Change
Renames the frontend npm package from `@dkhalife/tasks` to `@taskwiz/app`.

## Files changed
- `frontend/package.json` — `name` field
- `frontend/package-lock.json` — root `name` fields

## Verification
- `yarn build` ✅ passes
- `yarn lint` ✅ passes
- `git grep "@dkhalife/tasks" -- frontend .github` returns no matches

Scope limited to the frontend codebase; no dependency versions changed.