### PR TITLE
Rebrand: update release config and docs to taskwiz.app

### DIFF
--- a/.agents/features/calendar-sync.md
+++ b/.agents/features/calendar-sync.md
@@ -38,7 +38,7 @@ Five modular layers, each reusable independently:
 ### 5. Account authenticator (system integration)
 - `CalendarAccountAuthenticator` — stub authenticator required by Android for custom account types
 - `CalendarAuthenticatorService` — bound service exposing the authenticator
-- `res/xml/calendar_authenticator.xml` — declares the `com.dkhalife.tasks` account type
+- `res/xml/calendar_authenticator.xml` — declares the `app.taskwiz` account type
 - Without these, Android will not persist the calendar or make it visible to other apps
 
 ## Key Surfaces

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -8,9 +8,9 @@ builds:
   - CGO_ENABLED=0
   ldflags:
   - -s -w
-  - -X dkhalife.com/tasks/core/internal/version.Version={{.Version}}
-  - -X dkhalife.com/tasks/core/internal/version.BuildNumber={{.Env.GITHUB_RUN_NUMBER}}
-  - -X dkhalife.com/tasks/core/internal/version.CommitHash={{.ShortCommit}}
+  - -X taskwiz.app/core/internal/version.Version={{.Version}}
+  - -X taskwiz.app/core/internal/version.BuildNumber={{.Env.GITHUB_RUN_NUMBER}}
+  - -X taskwiz.app/core/internal/version.CommitHash={{.ShortCommit}}
   targets:
   - linux_amd64_v1
   - darwin_arm64


### PR DESCRIPTION
Part of the coordinated rebrand of Task Wizard from `tasks.dkhalife.com` to `taskwiz.app`. This PR owns the shared release config, CI, and documentation.