### PR TITLE
Export label-filter widget config activity

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -90,7 +90,7 @@
 
         <activity
             android:name=".ui.widget.labelfilter.LabelFilterConfigActivity"
-            android:exported="false"
+            android:exported="true"
             android:theme="@style/Theme.TaskWizard" />
 
         <provider


### PR DESCRIPTION
## Why

The label-filter app widget declares `android:configure` in `label_filter_widget_info.xml` pointing at `LabelFilterConfigActivity`, but that activity was declared `android:exported="false"` in the manifest. Widget hosts such as the launcher run in a separate app and cannot start a non-exported activity, so the widget's configuration flow would fail at runtime when a user drops the widget onto their home screen.

## What

Marks `LabelFilterConfigActivity` as `android:exported="true"`. This is the standard, expected pattern for an `APPWIDGET_CONFIGURE` activity: it only handles widget configuration (validating the passed `appWidgetId` and returning a result), so exporting it does not expose a sensitive entry point.