### PR TITLE
Enable Gradle build, parallel, and configuration caches for Android

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -1,4 +1,3 @@
-import java.io.ByteArrayOutputStream
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import java.util.Properties
@@ -32,13 +31,10 @@ fun calculateVersion(): Pair<Int, String> {
 
 fun resolveGitSha(): String {
     return try {
-        val output = ByteArrayOutputStream()
-        exec {
+        providers.exec {
             commandLine("git", "rev-parse", "HEAD")
-            standardOutput = output
             isIgnoreExitValue = true
-        }
-        output.toString().trim().ifBlank { "local" }
+        }.standardOutput.asText.get().trim().ifBlank { "local" }
     } catch (e: Exception) {
         "local"
     }

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -2,3 +2,6 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 android.useAndroidX=true
 kotlin.code.style=official
 android.nonTransitiveRClass=true
+org.gradle.caching=true
+org.gradle.parallel=true
+org.gradle.configuration-cache=true


### PR DESCRIPTION
## Summary

Enables Gradle's built-in caches for the Android project (`android/`) to speed up builds and allow compiled-output reuse across git worktrees. Config-only change plus one small build-script compatibility fix.

### Flags kept (all three)
Added to `android/gradle.properties`:
```
org.gradle.caching=true
org.gradle.parallel=true
org.gradle.configuration-cache=true
```

The local build cache lives in the shared `GRADLE_USER_HOME` (`~/.gradle`), so identical tasks compiled in one worktree are reused in another. `parallel` + `configuration-cache` speed up every build.

### Configuration-cache compatibility fix
Initial validation (`./gradlew help --configuration-cache`) failed with one problem: `resolveGitSha()` in `app/build.gradle.kts` started an external `git rev-parse HEAD` process at configuration time, which the configuration cache forbids.

This was trivially resolvable, so rather than dropping the flag I migrated it to the configuration-cache-compatible `providers.exec` API (and removed the now-unused `ByteArrayOutputStream` import). This keeps all three flags enabled with no behavior change to the embedded `GIT_SHA`.

### Build result
- `./gradlew help --configuration-cache` → **BUILD SUCCESSFUL**, configuration cache entry stored.
- `./gradlew :app:assembleDebug --configuration-cache` → **BUILD SUCCESSFUL**, debug APK assembled, configuration cache entry stored.

(One transient "Could not connect to Kotlin compile daemon" message appeared during assembly; Gradle automatically fell back to in-process compilation and the build completed successfully. It is environmental and unrelated to these flags.)

No frontend or Go apiserver changes; no bespoke scripts added.