### PR TITLE
Enable incremental caches for tsc and ESLint in frontend

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "vite --host",
     "build": "vite build --mode prod",
-    "lint": "eslint .",
+    "lint": "eslint . --cache --cache-location ./node_modules/.cache/eslint/",
     "preview": "vite preview",
     "test": "jest",
     "test:watch": "jest --watch",

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -8,6 +8,8 @@
     "moduleResolution": "node",
     "esModuleInterop": true,
     "skipLibCheck": true,
+    "incremental": true,
+    "tsBuildInfoFile": "./node_modules/.cache/tsc/tsconfig.tsbuildinfo",
     "strict": true,
     "forceConsistentCasingInFileNames": true,
     "baseUrl": "./",


### PR DESCRIPTION
## What

Purely incremental-cache configuration to speed up repeated TypeScript type-checking and ESLint runs in `frontend/`. **No behavior change.**

### Changes (limited to `frontend/`)
- **`tsconfig.json`**: added `"incremental": true` and `"tsBuildInfoFile": "./node_modules/.cache/tsc/tsconfig.tsbuildinfo"`. The build-info path lives inside `node_modules`, so it is naturally git-ignored.
- **`package.json`**: lint script changed from `eslint .` to `eslint . --cache --cache-location ./node_modules/.cache/eslint/`.

### Git-ignore
Both caches write under `node_modules/.cache`, and `node_modules` is already ignored in `frontend/.gitignore` — no `.gitignore` changes needed. Verified the cache artifacts are not tracked.

## Verification
All steps run in `frontend/` after `yarn install`:

| Step | Run 1 | Run 2 (cache hit) | Result |
|------|-------|-------------------|--------|
| `yarn tsc` | ~198s | ~83s | ✅ pass, faster |
| `yarn lint` | ~82s | ~17s | ✅ pass, faster |
| `yarn build` | — | — | ✅ succeeds |

The second `tsc` and `lint` runs are clearly faster thanks to the cache. Build (`vite build`) still succeeds and is unaffected.

## Scope note
Intentionally minimal — only `frontend/tsconfig.json` and `frontend/package.json`. Does not touch the in-flight Yarn package-manager migration or the Android/Gradle changes. The `yarn.lock` regeneration produced by a local install was reverted to avoid churn with the migration PR.