### PR TITLE
Add clock-skew tolerance to access token time validation

### DIFF
--- a/apiserver/internal/middleware/auth/auth.go
+++ b/apiserver/internal/middleware/auth/auth.go
@@ -22,6 +22,10 @@ import (
 
 const SessionCookieName = "tw_session"
 
+// clockSkewLeeway tolerates small clock differences between the identity
+// provider and this server when validating time-based token claims.
+const clockSkewLeeway = 2 * time.Minute
+
 type AuthMiddleware struct {
 	enabled     bool
 	keySet      oidc.KeySet
@@ -37,8 +41,21 @@ type accessTokenClaims struct {
 	Issuer    string `json:"iss"`
 	Audience  string `json:"aud"`
 	ExpiresAt int64  `json:"exp"`
+	NotBefore int64  `json:"nbf"`
 	TenantID  string `json:"tid"`
 	ObjectID  string `json:"oid"`
+}
+
+func validateTemporalClaims(claims accessTokenClaims, now time.Time, leeway time.Duration) error {
+	if now.Add(-leeway).Unix() > claims.ExpiresAt {
+		return fmt.Errorf("token has expired")
+	}
+
+	if claims.NotBefore != 0 && now.Add(leeway).Unix() < claims.NotBefore {
+		return fmt.Errorf("token is not yet valid")
+	}
+
+	return nil
 }
 
 func NewAuthMiddleware(cfg *config.Config, userRepo uRepo.IUserRepo, sessionRepo sRepo.ISessionRepo) (*AuthMiddleware, error) {
@@ -151,8 +168,8 @@ func (m *AuthMiddleware) verifyAccessToken(ctx context.Context, rawToken string)
 		return nil, fmt.Errorf("invalid token audience")
 	}
 
-	if time.Now().Unix() > claims.ExpiresAt {
-		return nil, fmt.Errorf("token has expired")
+	if err := validateTemporalClaims(claims, time.Now(), clockSkewLeeway); err != nil {
+		return nil, err
 	}
 
 	if claims.TenantID == "" || claims.ObjectID == "" {

--- a/apiserver/internal/middleware/auth/auth_test.go
+++ b/apiserver/internal/middleware/auth/auth_test.go
@@ -2,10 +2,13 @@ package auth
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"taskwiz.app/core/config"
 )
+
+const testLeeway = 2 * time.Minute
 
 func newDisabledAuthConfig(hostName string, allowInsecure bool) *config.Config {
 	return &config.Config{
@@ -44,4 +47,67 @@ func TestNewAuthMiddleware_DisabledWithoutHostName_Allowed(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, m)
 	assert.False(t, m.enabled)
+}
+
+func TestValidateTemporalClaims_WithinWindow_Valid(t *testing.T) {
+	now := time.Now()
+	claims := accessTokenClaims{
+		ExpiresAt: now.Add(10 * time.Minute).Unix(),
+		NotBefore: now.Add(-10 * time.Minute).Unix(),
+	}
+
+	assert.NoError(t, validateTemporalClaims(claims, now, testLeeway))
+}
+
+func TestValidateTemporalClaims_ExpiredWithinLeeway_Valid(t *testing.T) {
+	now := time.Now()
+	claims := accessTokenClaims{
+		ExpiresAt: now.Add(-1 * time.Minute).Unix(),
+	}
+
+	assert.NoError(t, validateTemporalClaims(claims, now, testLeeway))
+}
+
+func TestValidateTemporalClaims_ExpiredBeyondLeeway_Invalid(t *testing.T) {
+	now := time.Now()
+	claims := accessTokenClaims{
+		ExpiresAt: now.Add(-5 * time.Minute).Unix(),
+	}
+
+	err := validateTemporalClaims(claims, now, testLeeway)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "expired")
+}
+
+func TestValidateTemporalClaims_NotBeforeWithinLeeway_Valid(t *testing.T) {
+	now := time.Now()
+	claims := accessTokenClaims{
+		ExpiresAt: now.Add(10 * time.Minute).Unix(),
+		NotBefore: now.Add(1 * time.Minute).Unix(),
+	}
+
+	assert.NoError(t, validateTemporalClaims(claims, now, testLeeway))
+}
+
+func TestValidateTemporalClaims_NotBeforeBeyondLeeway_Invalid(t *testing.T) {
+	now := time.Now()
+	claims := accessTokenClaims{
+		ExpiresAt: now.Add(10 * time.Minute).Unix(),
+		NotBefore: now.Add(5 * time.Minute).Unix(),
+	}
+
+	err := validateTemporalClaims(claims, now, testLeeway)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not yet valid")
+}
+
+func TestValidateTemporalClaims_NotBeforeAbsent_Valid(t *testing.T) {
+	now := time.Now()
+	claims := accessTokenClaims{
+		ExpiresAt: now.Add(10 * time.Minute).Unix(),
+	}
+
+	assert.NoError(t, validateTemporalClaims(claims, now, testLeeway))
 }

--- a/apiserver/internal/middleware/auth/auth_test.go
+++ b/apiserver/internal/middleware/auth/auth_test.go
@@ -8,8 +8,6 @@ import (
 	"taskwiz.app/core/config"
 )
 
-const testLeeway = 2 * time.Minute
-
 func newDisabledAuthConfig(hostName string, allowInsecure bool) *config.Config {
 	return &config.Config{
 		Entra: config.EntraConfig{Enabled: false},
@@ -56,7 +54,7 @@ func TestValidateTemporalClaims_WithinWindow_Valid(t *testing.T) {
 		NotBefore: now.Add(-10 * time.Minute).Unix(),
 	}
 
-	assert.NoError(t, validateTemporalClaims(claims, now, testLeeway))
+	assert.NoError(t, validateTemporalClaims(claims, now, clockSkewLeeway))
 }
 
 func TestValidateTemporalClaims_ExpiredWithinLeeway_Valid(t *testing.T) {
@@ -65,7 +63,7 @@ func TestValidateTemporalClaims_ExpiredWithinLeeway_Valid(t *testing.T) {
 		ExpiresAt: now.Add(-1 * time.Minute).Unix(),
 	}
 
-	assert.NoError(t, validateTemporalClaims(claims, now, testLeeway))
+	assert.NoError(t, validateTemporalClaims(claims, now, clockSkewLeeway))
 }
 
 func TestValidateTemporalClaims_ExpiredBeyondLeeway_Invalid(t *testing.T) {
@@ -74,7 +72,7 @@ func TestValidateTemporalClaims_ExpiredBeyondLeeway_Invalid(t *testing.T) {
 		ExpiresAt: now.Add(-5 * time.Minute).Unix(),
 	}
 
-	err := validateTemporalClaims(claims, now, testLeeway)
+	err := validateTemporalClaims(claims, now, clockSkewLeeway)
 
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "expired")
@@ -87,7 +85,7 @@ func TestValidateTemporalClaims_NotBeforeWithinLeeway_Valid(t *testing.T) {
 		NotBefore: now.Add(1 * time.Minute).Unix(),
 	}
 
-	assert.NoError(t, validateTemporalClaims(claims, now, testLeeway))
+	assert.NoError(t, validateTemporalClaims(claims, now, clockSkewLeeway))
 }
 
 func TestValidateTemporalClaims_NotBeforeBeyondLeeway_Invalid(t *testing.T) {
@@ -97,7 +95,7 @@ func TestValidateTemporalClaims_NotBeforeBeyondLeeway_Invalid(t *testing.T) {
 		NotBefore: now.Add(5 * time.Minute).Unix(),
 	}
 
-	err := validateTemporalClaims(claims, now, testLeeway)
+	err := validateTemporalClaims(claims, now, clockSkewLeeway)
 
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "not yet valid")
@@ -109,5 +107,5 @@ func TestValidateTemporalClaims_NotBeforeAbsent_Valid(t *testing.T) {
 		ExpiresAt: now.Add(10 * time.Minute).Unix(),
 	}
 
-	assert.NoError(t, validateTemporalClaims(claims, now, testLeeway))
+	assert.NoError(t, validateTemporalClaims(claims, now, clockSkewLeeway))
 }


### PR DESCRIPTION
## Summary

Hardens access token validation in the API server auth middleware to be more robust around clock boundaries.

- Applies a small clock-skew leeway when validating token time-based claims so valid tokens are no longer rejected due to minor clock differences between the identity provider and the server.
- Adds validation of the token's not-before claim, consistent with the existing validation flow.

## Tests

- Added unit tests covering the time-based claim validation across the relevant boundary cases.
- `go build ./...`, `go test ./...`, and `golangci-lint run` all pass.