### PR TITLE
Add WebSocket message rate limiting and size cap

### DIFF
--- a/apiserver/internal/ws/server.go
+++ b/apiserver/internal/ws/server.go
@@ -20,11 +20,64 @@ import (
 	"taskwiz.app/core/internal/telemetry"
 )
 
+const (
+	// maxMessageBytes caps the size of a single inbound WebSocket message. WS
+	// payloads are small JSON mutations, so anything larger is rejected to avoid
+	// memory abuse from a flooding client.
+	maxMessageBytes = 32 * 1024
+	// messageRatePerSecond and messageBurst bound how frequently a single
+	// connection may send messages, mirroring the rate limiting applied to REST
+	// routes.
+	messageRatePerSecond = 20
+	messageBurst         = 40
+)
+
+// tokenBucket is a small, self-contained token-bucket rate limiter used to bound
+// the message rate of a single WebSocket connection.
+type tokenBucket struct {
+	mu         sync.Mutex
+	tokens     float64
+	maxTokens  float64
+	refillRate float64
+	last       time.Time
+}
+
+func newTokenBucket(ratePerSecond, burst float64) *tokenBucket {
+	return &tokenBucket{
+		tokens:     burst,
+		maxTokens:  burst,
+		refillRate: ratePerSecond,
+		last:       time.Now(),
+	}
+}
+
+// allow reports whether a message may be processed now, consuming one token when
+// it can.
+func (b *tokenBucket) allow() bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	now := time.Now()
+	b.tokens += now.Sub(b.last).Seconds() * b.refillRate
+	if b.tokens > b.maxTokens {
+		b.tokens = b.maxTokens
+	}
+	b.last = now
+
+	if b.tokens < 1 {
+		return false
+	}
+
+	b.tokens--
+	return true
+}
+
 // connection represents a single websocket connection with associated identity.
 type connection struct {
 	ws       *websocket.Conn
 	identity *models.SignedInIdentity
 	writeMu  sync.Mutex // Protects concurrent writes to websocket
+	limiter  *tokenBucket
 }
 
 // WSServer keeps track of active websocket connections.
@@ -146,7 +199,11 @@ func (s *WSServer) HandleConnection(c *gin.Context) {
 		return
 	}
 
-	conn := &connection{ws: wsConn, identity: identity}
+	conn := &connection{
+		ws:       wsConn,
+		identity: identity,
+		limiter:  newTokenBucket(messageRatePerSecond, messageBurst),
+	}
 
 	s.mu.Lock()
 	s.connections[wsConn] = conn
@@ -162,6 +219,7 @@ func (s *WSServer) HandleConnection(c *gin.Context) {
 // listen waits for messages on a connection and removes it when closed.
 func (s *WSServer) listen(ctx context.Context, conn *connection) {
 	wsConn := conn.ws
+	wsConn.SetReadLimit(maxMessageBytes)
 	if err := wsConn.SetReadDeadline(time.Now().Add(s.pongWait)); err != nil {
 		logging.FromContext(ctx).Errorf("set read deadline error: %v", err)
 	}
@@ -268,6 +326,21 @@ func (s *WSServer) handleMessage(ctx context.Context, conn *connection, msg WSMe
 	s.mu.RUnlock()
 
 	log := logging.FromContext(ctx)
+
+	if conn.limiter != nil && !conn.limiter.allow() {
+		log.Warnf("rate limit exceeded for user %d on action %s", conn.identity.UserID, msg.Action)
+		telemetry.TrackWarning(context.Background(), "ws_rate_limited", "ws-server", "Too many messages", nil)
+		resp := &WSResponse{
+			Action:    msg.Action,
+			RequestID: msg.RequestID,
+			Status:    http.StatusTooManyRequests,
+			Data:      map[string]string{"error": "Too many requests"},
+		}
+		if err := conn.safeWriteJSON(resp); err != nil {
+			log.Errorf("failed to write JSON to WebSocket: %v", err)
+		}
+		return
+	}
 
 	if !ok {
 		log.Errorf("no handler registered for action %s", msg.Action)

--- a/apiserver/internal/ws/server_test.go
+++ b/apiserver/internal/ws/server_test.go
@@ -210,3 +210,60 @@ func (s *WSServerTestSuite) TestHandleMessageRoutesResponse() {
 	s.Equal("echo", resp.Action)
 	s.Equal("hello", resp.Data)
 }
+
+func (s *WSServerTestSuite) TestOversizedMessageClosesConnection() {
+	ts := httptest.NewServer(s.router)
+	defer ts.Close()
+
+	conn, _, err := s.dial(ts)
+	s.Require().NoError(err)
+	defer conn.Close()
+
+	s.waitForConnections(1)
+
+	oversized := strings.Repeat("a", maxMessageBytes+1)
+	s.NoError(conn.WriteMessage(websocket.TextMessage, []byte(oversized)))
+
+	_, _, readErr := conn.ReadMessage()
+	s.Error(readErr)
+	s.waitForConnections(0)
+}
+
+func (s *WSServerTestSuite) TestRateLimitRejectsFlood() {
+	s.server.RegisterHandler("noop", func(ctx context.Context, userID int, msg WSMessage) *WSResponse {
+		return &WSResponse{Action: "noop", Status: http.StatusOK}
+	})
+
+	ts := httptest.NewServer(s.router)
+	defer ts.Close()
+
+	conn, _, err := s.dial(ts)
+	s.Require().NoError(err)
+	defer conn.Close()
+
+	s.waitForConnections(1)
+
+	rateLimited := false
+	for i := 0; i < messageBurst+5; i++ {
+		s.Require().NoError(conn.WriteJSON(WSMessage{RequestID: "r", Action: "noop"}))
+
+		var resp WSResponse
+		s.Require().NoError(conn.ReadJSON(&resp))
+		if resp.Status == http.StatusTooManyRequests {
+			rateLimited = true
+			break
+		}
+	}
+
+	s.True(rateLimited, "expected at least one message to be rate limited")
+}
+
+func (s *WSServerTestSuite) TestTokenBucketRefills() {
+	b := newTokenBucket(1000, 2)
+	s.True(b.allow())
+	s.True(b.allow())
+	s.False(b.allow())
+
+	time.Sleep(10 * time.Millisecond)
+	s.True(b.allow(), "tokens should refill over time")
+}

--- a/apiserver/internal/ws/server_test.go
+++ b/apiserver/internal/ws/server_test.go
@@ -221,8 +221,17 @@ func (s *WSServerTestSuite) TestOversizedMessageClosesConnection() {
 
 	s.waitForConnections(1)
 
-	oversized := strings.Repeat("a", maxMessageBytes+1)
-	s.NoError(conn.WriteMessage(websocket.TextMessage, []byte(oversized)))
+	// Build a valid JSON WSMessage whose total encoded size exceeds maxMessageBytes.
+	// Sending raw non-JSON would also close the connection (JSON decode failure),
+	// so we need a syntactically valid frame to isolate the size-cap behavior.
+	largeData := json.RawMessage(`"` + strings.Repeat("a", maxMessageBytes) + `"`)
+	payload := WSMessage{RequestID: "r", Action: "echo", Data: largeData}
+	raw, marshalErr := json.Marshal(payload)
+	s.Require().NoError(marshalErr)
+	s.Require().Greater(len(raw), maxMessageBytes, "sanity: test frame must exceed the server read limit")
+
+	s.Require().NoError(conn.SetReadDeadline(time.Now().Add(3 * time.Second)))
+	s.NoError(conn.WriteMessage(websocket.TextMessage, raw))
 
 	_, _, readErr := conn.ReadMessage()
 	s.Error(readErr)
@@ -243,8 +252,23 @@ func (s *WSServerTestSuite) TestRateLimitRejectsFlood() {
 
 	s.waitForConnections(1)
 
+	// Replace the connection's limiter with a zero-refill bucket of exactly 2
+	// tokens so rate-limit behaviour is deterministic regardless of test duration.
+	const burst = 2
+	s.server.mu.RLock()
+	for _, c := range s.server.connections {
+		c.limiter = &tokenBucket{
+			tokens:     burst,
+			maxTokens:  burst,
+			refillRate: 0,
+			last:       time.Now(),
+		}
+	}
+	s.server.mu.RUnlock()
+
+	gotOK := 0
 	rateLimited := false
-	for i := 0; i < messageBurst+5; i++ {
+	for i := 0; i < burst+3; i++ {
 		s.Require().NoError(conn.WriteJSON(WSMessage{RequestID: "r", Action: "noop"}))
 
 		var resp WSResponse
@@ -253,9 +277,11 @@ func (s *WSServerTestSuite) TestRateLimitRejectsFlood() {
 			rateLimited = true
 			break
 		}
+		gotOK++
 	}
 
-	s.True(rateLimited, "expected at least one message to be rate limited")
+	s.True(rateLimited, "expected a 429 after burst tokens are exhausted")
+	s.Equal(burst, gotOK, "expected exactly burst messages to succeed before rate limiting")
 }
 
 func (s *WSServerTestSuite) TestTokenBucketRefills() {
@@ -264,6 +290,9 @@ func (s *WSServerTestSuite) TestTokenBucketRefills() {
 	s.True(b.allow())
 	s.False(b.allow())
 
-	time.Sleep(10 * time.Millisecond)
+	// Simulate elapsed time by backdating last — no wall-clock sleep needed.
+	b.mu.Lock()
+	b.last = time.Now().Add(-10 * time.Millisecond)
+	b.mu.Unlock()
 	s.True(b.allow(), "tokens should refill over time")
 }


### PR DESCRIPTION
## Summary

Hardens the authenticated WebSocket channel by adding two per-connection limits that previously only existed for REST traffic:

- **Per-message size cap** — inbound messages larger than the limit are rejected.
- **Per-connection message rate limit** — a token-bucket limiter bounds how frequently a single connection may send messages. Excess messages are rejected with a `429 Too Many Requests` response rather than dropping the connection.

Sane defaults are applied and the limits are self-contained (no new external dependencies).

## Testing

- `go build ./...`
- `go test ./...` (WS suite passes; pre-existing unrelated failures in user repo/service tests are not affected by this change)
- `golangci-lint run`

New tests cover oversized-message rejection, rate-limit enforcement, and the token-bucket refill behavior.