### PR TITLE
Validate outbound notification request targets

### DIFF
--- a/apiserver/internal/services/notifications/gotify.go
+++ b/apiserver/internal/services/notifications/gotify.go
@@ -6,6 +6,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
+	"time"
 
 	"taskwiz.app/core/internal/models"
 	"taskwiz.app/core/internal/services/logging"
@@ -25,12 +27,18 @@ func SendNotificationViaGotify(c context.Context, provider models.NotificationPr
 	log := logging.FromContext(c)
 	log.Debug("Sending notification via Gotify")
 
+	endpoint := strings.TrimRight(provider.URL, "/") + "/message"
+	parsedURL, err := validateOutboundURL(endpoint)
+	if err != nil {
+		return err
+	}
+
 	jsonData, err := json.Marshal(msg)
 	if err != nil {
 		return fmt.Errorf("failed to marshal message: %s", err.Error())
 	}
 
-	req, err := http.NewRequest("POST", provider.URL+"/message", bytes.NewBuffer(jsonData))
+	req, err := http.NewRequestWithContext(c, http.MethodPost, parsedURL.String(), bytes.NewBuffer(jsonData))
 	if err != nil {
 		return fmt.Errorf("failed to create HTTP request: %s", err.Error())
 	}
@@ -38,7 +46,7 @@ func SendNotificationViaGotify(c context.Context, provider models.NotificationPr
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("X-Gotify-Key", provider.Token)
 
-	client := &http.Client{}
+	client := newSafeHTTPClient(10 * time.Second)
 	resp, err := client.Do(req)
 	if err != nil {
 		return fmt.Errorf("failed to send HTTP request: %s", err.Error())

--- a/apiserver/internal/services/notifications/safehttp.go
+++ b/apiserver/internal/services/notifications/safehttp.go
@@ -16,6 +16,8 @@ var allowedOutboundMethods = map[string]struct{}{
 	http.MethodPut:  {},
 }
 
+const errDestinationNotAllowed = "destination not allowed"
+
 // isDisallowedIP reports whether an IP must not be reached by an outbound
 // server-side request. It blocks loopback, link-local (including cloud metadata
 // at 169.254.169.254), private, unspecified and multicast ranges.
@@ -76,12 +78,12 @@ func newSafeHTTPClient(timeout time.Duration) *http.Client {
 		Control: func(_, address string, _ syscall.RawConn) error {
 			host, _, err := net.SplitHostPort(address)
 			if err != nil {
-				return fmt.Errorf("destination not allowed")
+				return fmt.Errorf("%s", errDestinationNotAllowed)
 			}
 
 			ip := net.ParseIP(host)
 			if isDisallowedIP(ip) {
-				return fmt.Errorf("destination not allowed")
+				return fmt.Errorf("%s", errDestinationNotAllowed)
 			}
 
 			return nil
@@ -98,5 +100,8 @@ func newSafeHTTPClient(timeout time.Duration) *http.Client {
 	return &http.Client{
 		Timeout:   timeout,
 		Transport: transport,
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
 	}
 }

--- a/apiserver/internal/services/notifications/safehttp.go
+++ b/apiserver/internal/services/notifications/safehttp.go
@@ -1,0 +1,102 @@
+package notifications
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"syscall"
+	"time"
+)
+
+var allowedOutboundMethods = map[string]struct{}{
+	http.MethodPost: {},
+	http.MethodPut:  {},
+}
+
+// isDisallowedIP reports whether an IP must not be reached by an outbound
+// server-side request. It blocks loopback, link-local (including cloud metadata
+// at 169.254.169.254), private, unspecified and multicast ranges.
+func isDisallowedIP(ip net.IP) bool {
+	if ip == nil {
+		return true
+	}
+
+	if ip4 := ip.To4(); ip4 != nil {
+		ip = ip4
+	}
+
+	if ip.IsLoopback() || ip.IsUnspecified() ||
+		ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() ||
+		ip.IsMulticast() || ip.IsPrivate() {
+		return true
+	}
+
+	return false
+}
+
+// validateOutboundURL enforces the scheme allow-list and returns the parsed URL.
+func validateOutboundURL(rawURL string) (*url.URL, error) {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid URL")
+	}
+
+	switch strings.ToLower(parsed.Scheme) {
+	case "http", "https":
+	default:
+		return nil, fmt.Errorf("unsupported URL scheme")
+	}
+
+	if parsed.Hostname() == "" {
+		return nil, fmt.Errorf("invalid URL")
+	}
+
+	return parsed, nil
+}
+
+// validateOutboundMethod normalizes and enforces the method allow-list.
+func validateOutboundMethod(method string) (string, error) {
+	normalized := strings.ToUpper(strings.TrimSpace(method))
+	if _, ok := allowedOutboundMethods[normalized]; !ok {
+		return "", fmt.Errorf("unsupported HTTP method")
+	}
+
+	return normalized, nil
+}
+
+// newSafeHTTPClient builds an HTTP client whose dialer validates the resolved IP
+// at connect time. Checking the address inside Control closes the DNS-rebinding
+// window between resolution and connection.
+func newSafeHTTPClient(timeout time.Duration) *http.Client {
+	dialer := &net.Dialer{
+		Timeout: timeout,
+		Control: func(_, address string, _ syscall.RawConn) error {
+			host, _, err := net.SplitHostPort(address)
+			if err != nil {
+				return fmt.Errorf("destination not allowed")
+			}
+
+			ip := net.ParseIP(host)
+			if isDisallowedIP(ip) {
+				return fmt.Errorf("destination not allowed")
+			}
+
+			return nil
+		},
+	}
+
+	transport := &http.Transport{
+		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			return dialer.DialContext(ctx, network, addr)
+		},
+		Proxy: nil,
+	}
+
+	return &http.Client{
+		Timeout:   timeout,
+		Transport: transport,
+	}
+}

--- a/apiserver/internal/services/notifications/safehttp_test.go
+++ b/apiserver/internal/services/notifications/safehttp_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 )
@@ -116,5 +117,9 @@ func TestSafeClientBlocksLoopback(t *testing.T) {
 	if err == nil {
 		resp.Body.Close()
 		t.Fatal("expected loopback connection to be blocked")
+	}
+
+	if !strings.Contains(err.Error(), errDestinationNotAllowed) {
+		t.Fatalf("expected dialer rejection error, got: %v", err)
 	}
 }

--- a/apiserver/internal/services/notifications/safehttp_test.go
+++ b/apiserver/internal/services/notifications/safehttp_test.go
@@ -1,0 +1,120 @@
+package notifications
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestIsDisallowedIP(t *testing.T) {
+	cases := []struct {
+		name       string
+		ip         string
+		disallowed bool
+	}{
+		{"loopback v4", "127.0.0.1", true},
+		{"loopback range", "127.5.6.7", true},
+		{"loopback v6", "::1", true},
+		{"unspecified v4", "0.0.0.0", true},
+		{"unspecified v6", "::", true},
+		{"link-local metadata", "169.254.169.254", true},
+		{"link-local v6", "fe80::1", true},
+		{"private 10", "10.0.0.5", true},
+		{"private 172", "172.16.3.4", true},
+		{"private 192", "192.168.1.1", true},
+		{"unique local v6", "fc00::1", true},
+		{"multicast v4", "224.0.0.1", true},
+		{"public v4", "8.8.8.8", false},
+		{"public v4 alt", "1.1.1.1", false},
+		{"public v6", "2606:4700:4700::1111", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ip := net.ParseIP(tc.ip)
+			if got := isDisallowedIP(ip); got != tc.disallowed {
+				t.Fatalf("isDisallowedIP(%s) = %v, want %v", tc.ip, got, tc.disallowed)
+			}
+		})
+	}
+}
+
+func TestIsDisallowedIPNil(t *testing.T) {
+	if !isDisallowedIP(nil) {
+		t.Fatal("nil IP must be disallowed")
+	}
+}
+
+func TestValidateOutboundURL(t *testing.T) {
+	cases := []struct {
+		name    string
+		url     string
+		wantErr bool
+	}{
+		{"https", "https://example.com/hook", false},
+		{"http", "http://example.com/hook", false},
+		{"uppercase scheme", "HTTPS://example.com", false},
+		{"file scheme", "file:///etc/passwd", true},
+		{"gopher scheme", "gopher://example.com", true},
+		{"ftp scheme", "ftp://example.com", true},
+		{"no scheme", "example.com/hook", true},
+		{"empty", "", true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := validateOutboundURL(tc.url)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("validateOutboundURL(%q) err = %v, wantErr %v", tc.url, err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateOutboundMethod(t *testing.T) {
+	cases := []struct {
+		name    string
+		method  string
+		want    string
+		wantErr bool
+	}{
+		{"post", "POST", "POST", false},
+		{"put", "PUT", "PUT", false},
+		{"lowercase post", "post", "POST", false},
+		{"padded put", " put ", "PUT", false},
+		{"get", "GET", "", true},
+		{"delete", "DELETE", "", true},
+		{"empty", "", "", true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := validateOutboundMethod(tc.method)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("validateOutboundMethod(%q) err = %v, wantErr %v", tc.method, err, tc.wantErr)
+			}
+			if got != tc.want {
+				t.Fatalf("validateOutboundMethod(%q) = %q, want %q", tc.method, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestSafeClientBlocksLoopback verifies the dialer Control callback rejects a
+// loopback connection at connect time even when the request is otherwise valid.
+func TestSafeClientBlocksLoopback(t *testing.T) {
+	client := newSafeHTTPClient(2 * time.Second)
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, "http://127.0.0.1:1/hook", nil)
+	if err != nil {
+		t.Fatalf("unexpected error building request: %v", err)
+	}
+
+	resp, err := client.Do(req)
+	if err == nil {
+		resp.Body.Close()
+		t.Fatal("expected loopback connection to be blocked")
+	}
+}

--- a/apiserver/internal/services/notifications/webhook.go
+++ b/apiserver/internal/services/notifications/webhook.go
@@ -12,7 +12,16 @@ import (
 )
 
 func SendNotificationViaWebhook(c context.Context, provider models.NotificationProvider, message string) error {
-	// Create the payload
+	parsedURL, err := validateOutboundURL(provider.URL)
+	if err != nil {
+		return err
+	}
+
+	method, err := validateOutboundMethod(provider.Method)
+	if err != nil {
+		return err
+	}
+
 	payload := map[string]string{
 		"message": message,
 	}
@@ -22,14 +31,14 @@ func SendNotificationViaWebhook(c context.Context, provider models.NotificationP
 		return fmt.Errorf("error marshalling payload: %s", err.Error())
 	}
 
-	req, err := http.NewRequest(provider.Method, provider.URL, bytes.NewBuffer(payloadBytes))
+	req, err := http.NewRequestWithContext(c, method, parsedURL.String(), bytes.NewBuffer(payloadBytes))
 	if err != nil {
 		return fmt.Errorf("error creating HTTP request: %s", err.Error())
 	}
 
 	req.Header.Set("Content-Type", "application/json")
 
-	client := &http.Client{Timeout: 10 * time.Second}
+	client := newSafeHTTPClient(10 * time.Second)
 	resp, err := client.Do(req)
 	if err != nil {
 		return fmt.Errorf("error sending HTTP request: %s", err.Error())


### PR DESCRIPTION
## Summary

Hardens the notification delivery path so that user-configured webhook and Gotify targets can only reach legitimate external destinations.

- Restricts outbound notification requests to `http`/`https` URLs.
- Restricts the webhook HTTP method to `POST`/`PUT`.
- Rejects requests to non-public address ranges (loopback, link-local, private, unspecified, multicast), validated at connection time.

## Tests

- New unit tests for URL/scheme validation, method validation, address filtering, and connection-time enforcement.
- `go build ./...`, `go test ./internal/services/notifications/...`, and `golangci-lint run` pass.

A pre-existing, unrelated test failure in the users service (`TestProcessDeletions_DeletesExpiredUsers`) exists on the base branch and is out of scope here.