### PR TITLE
fix(apiserver): set session cookie Secure flag from request scheme

### DIFF
--- a/apiserver/internal/apis/user.go
+++ b/apiserver/internal/apis/user.go
@@ -132,7 +132,7 @@ func (h *UsersAPIHandler) CreateSession(c *gin.Context) {
 		return
 	}
 
-	secure := h.cfg.Server.HostName != ""
+	secure := middleware.EffectiveScheme(c) == "https"
 	c.SetSameSite(http.SameSiteLaxMode)
 	c.SetCookie(authMW.SessionCookieName, rawToken, int(duration.Seconds()), "/", "", secure, true)
 	c.Status(http.StatusCreated)
@@ -144,7 +144,7 @@ func (h *UsersAPIHandler) DeleteCurrentSession(c *gin.Context) {
 		_ = h.sessionRepo.DeleteSession(c, sessionToken)
 	}
 
-	secure := h.cfg.Server.HostName != ""
+	secure := middleware.EffectiveScheme(c) == "https"
 	c.SetSameSite(http.SameSiteLaxMode)
 	c.SetCookie(authMW.SessionCookieName, "", -1, "/", "", secure, true)
 	c.Status(http.StatusNoContent)

--- a/apiserver/internal/utils/middleware/middleware.go
+++ b/apiserver/internal/utils/middleware/middleware.go
@@ -49,7 +49,7 @@ func RateLimitMiddleware(limiter *limiter.Limiter) gin.HandlerFunc {
 	}
 }
 
-func effectiveScheme(c *gin.Context) string {
+func EffectiveScheme(c *gin.Context) string {
 	if forwarded := c.GetHeader("X-Forwarded-Proto"); forwarded != "" {
 		scheme := forwarded
 		if i := strings.IndexByte(scheme, ','); i >= 0 {
@@ -70,7 +70,7 @@ func SecurityHeaders(cfg *config.Config) gin.HandlerFunc {
 	port := cfg.Server.Port
 
 	return func(c *gin.Context) {
-		scheme := effectiveScheme(c)
+		scheme := EffectiveScheme(c)
 		if scheme == "http" && hostName != "" {
 			target := fmt.Sprintf("https://%s", hostName)
 			if port != 443 {

--- a/apiserver/internal/utils/middleware/middleware_test.go
+++ b/apiserver/internal/utils/middleware/middleware_test.go
@@ -217,3 +217,58 @@ func (s *MiddlewareTestSuite) TestSecurityHeadersNoRedirectForHTTPS() {
 	s.Equal(http.StatusOK, w.Code)
 	s.Equal("max-age=31536000; includeSubDomains; preload", w.Header().Get("Strict-Transport-Security"))
 }
+
+func (s *MiddlewareTestSuite) TestEffectiveSchemeForwardedHTTPS() {
+	var scheme string
+	s.router.GET("/", func(c *gin.Context) {
+		scheme = EffectiveScheme(c)
+		c.Status(http.StatusOK)
+	})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/", nil)
+	req.Header.Set("X-Forwarded-Proto", "https")
+	s.router.ServeHTTP(w, req)
+	s.Equal("https", scheme)
+}
+
+func (s *MiddlewareTestSuite) TestEffectiveSchemeForwardedHTTPSWithList() {
+	var scheme string
+	s.router.GET("/", func(c *gin.Context) {
+		scheme = EffectiveScheme(c)
+		c.Status(http.StatusOK)
+	})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/", nil)
+	req.Header.Set("X-Forwarded-Proto", "https, http")
+	s.router.ServeHTTP(w, req)
+	s.Equal("https", scheme)
+}
+
+func (s *MiddlewareTestSuite) TestEffectiveSchemeDirectTLS() {
+	var scheme string
+	s.router.GET("/", func(c *gin.Context) {
+		scheme = EffectiveScheme(c)
+		c.Status(http.StatusOK)
+	})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/", nil)
+	req.TLS = &tls.ConnectionState{}
+	s.router.ServeHTTP(w, req)
+	s.Equal("https", scheme)
+}
+
+func (s *MiddlewareTestSuite) TestEffectiveSchemePlainHTTP() {
+	var scheme string
+	s.router.GET("/", func(c *gin.Context) {
+		scheme = EffectiveScheme(c)
+		c.Status(http.StatusOK)
+	})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/", nil)
+	s.router.ServeHTTP(w, req)
+	s.Equal("http", scheme)
+}


### PR DESCRIPTION
## Summary

The session cookie's `Secure` attribute is now derived from the effective request scheme rather than the configured host name. This ensures the cookie is marked `Secure` whenever the request is served over HTTPS — including behind a TLS-terminating proxy — while plain HTTP local development continues to work.

## Changes

- Reuse the existing request-scheme helper (which honors trusted forwarded headers and direct TLS) when issuing and clearing the session cookie.
- Add unit tests covering forwarded-HTTPS, direct TLS, and plain-HTTP cases.

## Validation

- `go build ./...`
- `go test ./internal/utils/middleware/...`
- `golangci-lint run`