### PR TITLE
fix(frontend): scope MSAL token cache to session storage

### DIFF
--- a/frontend/src/utils/msal.ts
+++ b/frontend/src/utils/msal.ts
@@ -30,7 +30,7 @@ const doInitializeMsal = async () => {
       redirectUri: `${window.location.origin}/login`,
     },
     cache: {
-      cacheLocation: 'localStorage',
+      cacheLocation: 'sessionStorage',
     },
   })
 


### PR DESCRIPTION
## Summary

Changes the MSAL browser cache from persistent storage to `sessionStorage` so cached auth artifacts are no longer retained across browser sessions or shared between tabs. This reduces the exposure window for client-side credentials.

## Details

- `frontend/src/utils/msal.ts`: `cacheLocation` set to `sessionStorage`.
- The hot-path token already lives in an in-memory cache, so login, silent token acquisition, refresh, and redirect handling are unaffected.

## Validation

- `yarn lint` — passes
- `yarn build` — passes
- `yarn test` — all suites pass (including the MSAL util tests)

Note: a pre-existing, unrelated `tsc` issue with `@mui/icons-material` type resolution in `LabelView.tsx` is present on the base branch and is out of scope here.