### PR TITLE
Configure trusted proxies for forwarded client metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ The configuration files are yaml mappings with the following values:
 | `server.log_level`                       | `debug` when `server.debug` = `true`, else `warn`   | The min level to log (debug, info, warn, error, dpanic, panic, fatal).      |
 | `server.allowed_origins`                 | `(empty)`                                           | Origins allowed to issue cross-domain requests.                             |
 | `server.allow_credentials`               | `false`                                             | Whether cross-domain requests can include credentials.                      |
+| `server.trusted_proxies`                 | `(empty)`                                           | CIDRs/IPs of reverse proxies allowed to set `X-Forwarded-*` headers. Empty trusts no proxy and uses the direct peer address. |
 | `scheduler_jobs.due_frequency`           | `5m`                                                | The interval for sending regular notifications.                             |
 | `scheduler_jobs.overdue_frequency`       | `24h`                                               | The interval for sending overdue notifications.                             |
 | `scheduler_jobs.notification_cleanup`    | `10m`                                               | The interval for cleaning up sent notifications.                            |

--- a/apiserver/config/config.dev.yaml
+++ b/apiserver/config/config.dev.yaml
@@ -16,6 +16,7 @@ server:
   allowed_origins:
     - http://localhost:5173
   allow_cors_credentials: true
+  trusted_proxies: []
 scheduler_jobs:
   due_frequency: 1m
   overdue_frequency: 1m

--- a/apiserver/config/config.go
+++ b/apiserver/config/config.go
@@ -2,7 +2,9 @@ package config
 
 import (
 	"fmt"
+	"net"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/spf13/viper"
@@ -48,6 +50,7 @@ type ServerConfig struct {
 	AllowCorsCredentials bool          `mapstructure:"allow_cors_credentials" yaml:"allow_cors_credentials"`
 	SessionDuration      time.Duration `mapstructure:"session_duration" yaml:"session_duration" default:"720h"`
 	AllowInsecureNoAuth  bool          `mapstructure:"allow_insecure_no_auth" yaml:"allow_insecure_no_auth"`
+	TrustedProxies       []string      `mapstructure:"trusted_proxies" yaml:"trusted_proxies"`
 }
 
 type SchedulerConfig struct {
@@ -118,4 +121,37 @@ func ValidateCorsConfig(cfg *Config) error {
 	}
 
 	return nil
+}
+
+// ParseTrustedProxies converts the configured trusted proxy entries into
+// network ranges. Each entry may be a CIDR (e.g. "10.0.0.0/8") or a bare IP
+// address (e.g. "192.168.1.1"), which is treated as a single-host range. An
+// empty configuration yields no trusted ranges, meaning no proxy is trusted.
+func ParseTrustedProxies(entries []string) ([]*net.IPNet, error) {
+	nets := make([]*net.IPNet, 0, len(entries))
+
+	for _, entry := range entries {
+		entry = strings.TrimSpace(entry)
+		if entry == "" {
+			continue
+		}
+
+		if _, ipNet, err := net.ParseCIDR(entry); err == nil {
+			nets = append(nets, ipNet)
+			continue
+		}
+
+		ip := net.ParseIP(entry)
+		if ip == nil {
+			return nil, fmt.Errorf("invalid trusted proxy entry: %q", entry)
+		}
+
+		bits := 32
+		if ip.To4() == nil {
+			bits = 128
+		}
+		nets = append(nets, &net.IPNet{IP: ip, Mask: net.CIDRMask(bits, bits)})
+	}
+
+	return nets, nil
 }

--- a/apiserver/config/config.yaml
+++ b/apiserver/config/config.yaml
@@ -18,6 +18,7 @@ server:
   serve_frontend: true
   registration: true
   log_level: "warn"
+  trusted_proxies: []
 scheduler_jobs:
   due_frequency: 5m
   overdue_frequency: 24h

--- a/apiserver/config/config_test.go
+++ b/apiserver/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"net"
 	"os"
 	"testing"
 	"time"
@@ -59,6 +60,29 @@ scheduler_jobs:
 
 	assert.Equal(t, 5*time.Minute, cfg.SchedulerJobs.DueFrequency)
 	assert.Equal(t, 24*time.Hour, cfg.SchedulerJobs.OverdueFrequency)
+}
+
+func TestParseTrustedProxies(t *testing.T) {
+	nets, err := ParseTrustedProxies([]string{"10.0.0.0/8", "192.168.1.1", " ", "::1"})
+	assert.NoError(t, err)
+	assert.Len(t, nets, 3)
+
+	assert.True(t, nets[0].Contains(net.ParseIP("10.1.2.3")))
+	assert.False(t, nets[0].Contains(net.ParseIP("11.0.0.1")))
+	assert.True(t, nets[1].Contains(net.ParseIP("192.168.1.1")))
+	assert.False(t, nets[1].Contains(net.ParseIP("192.168.1.2")))
+	assert.True(t, nets[2].Contains(net.ParseIP("::1")))
+}
+
+func TestParseTrustedProxies_Empty(t *testing.T) {
+	nets, err := ParseTrustedProxies(nil)
+	assert.NoError(t, err)
+	assert.Empty(t, nets)
+}
+
+func TestParseTrustedProxies_Invalid(t *testing.T) {
+	_, err := ParseTrustedProxies([]string{"not-an-ip"})
+	assert.Error(t, err)
 }
 
 func TestLoadConfig_PanicOnMissingFile(t *testing.T) {

--- a/apiserver/internal/utils/middleware/middleware.go
+++ b/apiserver/internal/utils/middleware/middleware.go
@@ -2,6 +2,7 @@ package middleware
 
 import (
 	"fmt"
+	"net"
 	"net/http"
 	"strconv"
 	"strings"
@@ -49,13 +50,34 @@ func RateLimitMiddleware(limiter *limiter.Limiter) gin.HandlerFunc {
 	}
 }
 
-func effectiveScheme(c *gin.Context) string {
-	if forwarded := c.GetHeader("X-Forwarded-Proto"); forwarded != "" {
-		scheme := forwarded
-		if i := strings.IndexByte(scheme, ','); i >= 0 {
-			scheme = scheme[:i]
+func isTrustedPeer(c *gin.Context, trusted []*net.IPNet) bool {
+	if len(trusted) == 0 {
+		return false
+	}
+
+	ip := net.ParseIP(c.RemoteIP())
+	if ip == nil {
+		return false
+	}
+
+	for _, n := range trusted {
+		if n.Contains(ip) {
+			return true
 		}
-		return strings.ToLower(strings.TrimSpace(scheme))
+	}
+
+	return false
+}
+
+func effectiveScheme(c *gin.Context, trusted []*net.IPNet) string {
+	if isTrustedPeer(c, trusted) {
+		if forwarded := c.GetHeader("X-Forwarded-Proto"); forwarded != "" {
+			scheme := forwarded
+			if i := strings.IndexByte(scheme, ','); i >= 0 {
+				scheme = scheme[:i]
+			}
+			return strings.ToLower(strings.TrimSpace(scheme))
+		}
 	}
 
 	if c.Request.TLS != nil {
@@ -69,8 +91,13 @@ func SecurityHeaders(cfg *config.Config) gin.HandlerFunc {
 	hostName := cfg.Server.HostName
 	port := cfg.Server.Port
 
+	trusted, err := config.ParseTrustedProxies(cfg.Server.TrustedProxies)
+	if err != nil {
+		panic(fmt.Sprintf("invalid trusted_proxies configuration: %s", err.Error()))
+	}
+
 	return func(c *gin.Context) {
-		scheme := effectiveScheme(c)
+		scheme := effectiveScheme(c, trusted)
 		if scheme == "http" && hostName != "" {
 			target := fmt.Sprintf("https://%s", hostName)
 			if port != 443 {

--- a/apiserver/internal/utils/middleware/middleware_test.go
+++ b/apiserver/internal/utils/middleware/middleware_test.go
@@ -96,8 +96,9 @@ func (s *MiddlewareTestSuite) TestRateLimitMiddlewareStoreFailure() {
 func (s *MiddlewareTestSuite) TestSecurityHeadersAddsHSTS() {
 	cfg := &config.Config{
 		Server: config.ServerConfig{
-			HostName: "example.com",
-			Port:     443,
+			HostName:       "example.com",
+			Port:           443,
+			TrustedProxies: []string{"192.0.2.0/24"},
 		},
 	}
 
@@ -108,6 +109,7 @@ func (s *MiddlewareTestSuite) TestSecurityHeadersAddsHSTS() {
 
 	w := httptest.NewRecorder()
 	req, _ := http.NewRequest("GET", "/", nil)
+	req.RemoteAddr = "192.0.2.1:1234"
 	req.Header.Set("X-Forwarded-Proto", "https")
 	s.router.ServeHTTP(w, req)
 	s.Equal(http.StatusOK, w.Code)
@@ -200,6 +202,29 @@ func (s *MiddlewareTestSuite) TestSecurityHeadersRedirectsHTTPNonStandardPort() 
 func (s *MiddlewareTestSuite) TestSecurityHeadersNoRedirectForHTTPS() {
 	cfg := &config.Config{
 		Server: config.ServerConfig{
+			HostName:       "example.com",
+			Port:           443,
+			TrustedProxies: []string{"192.0.2.0/24"},
+		},
+	}
+
+	s.router.Use(SecurityHeaders(cfg))
+	s.router.GET("/", func(c *gin.Context) {
+		c.String(http.StatusOK, "OK")
+	})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/", nil)
+	req.RemoteAddr = "192.0.2.1:1234"
+	req.Header.Set("X-Forwarded-Proto", "https")
+	s.router.ServeHTTP(w, req)
+	s.Equal(http.StatusOK, w.Code)
+	s.Equal("max-age=31536000; includeSubDomains; preload", w.Header().Get("Strict-Transport-Security"))
+}
+
+func (s *MiddlewareTestSuite) TestSecurityHeadersIgnoresForwardedProtoFromUntrustedPeer() {
+	cfg := &config.Config{
+		Server: config.ServerConfig{
 			HostName: "example.com",
 			Port:     443,
 		},
@@ -212,8 +237,32 @@ func (s *MiddlewareTestSuite) TestSecurityHeadersNoRedirectForHTTPS() {
 
 	w := httptest.NewRecorder()
 	req, _ := http.NewRequest("GET", "/", nil)
+	req.RemoteAddr = "192.0.2.1:1234"
 	req.Header.Set("X-Forwarded-Proto", "https")
 	s.router.ServeHTTP(w, req)
-	s.Equal(http.StatusOK, w.Code)
-	s.Equal("max-age=31536000; includeSubDomains; preload", w.Header().Get("Strict-Transport-Security"))
+	s.Equal(http.StatusMovedPermanently, w.Code)
+	s.Empty(w.Header().Get("Strict-Transport-Security"))
+}
+
+func (s *MiddlewareTestSuite) TestSecurityHeadersIgnoresForwardedProtoFromOutsideTrustedRange() {
+	cfg := &config.Config{
+		Server: config.ServerConfig{
+			HostName:       "example.com",
+			Port:           443,
+			TrustedProxies: []string{"10.0.0.0/8"},
+		},
+	}
+
+	s.router.Use(SecurityHeaders(cfg))
+	s.router.GET("/", func(c *gin.Context) {
+		c.String(http.StatusOK, "OK")
+	})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/", nil)
+	req.RemoteAddr = "203.0.113.5:1234"
+	req.Header.Set("X-Forwarded-Proto", "https")
+	s.router.ServeHTTP(w, req)
+	s.Equal(http.StatusMovedPermanently, w.Code)
+	s.Empty(w.Header().Get("Strict-Transport-Security"))
 }

--- a/apiserver/main.go
+++ b/apiserver/main.go
@@ -127,6 +127,9 @@ func newServer(lc fx.Lifecycle, cfg *config.Config, db *gorm.DB, bgScheduler *sc
 	}
 
 	r := gin.New()
+	if err := r.SetTrustedProxies(cfg.Server.TrustedProxies); err != nil {
+		log.Fatalf("invalid trusted_proxies configuration: %s", err.Error())
+	}
 	srv := &http.Server{
 		Addr:         fmt.Sprintf(":%d", cfg.Server.Port),
 		Handler:      r,


### PR DESCRIPTION
## Summary

Adds a `server.trusted_proxies` configuration option and wires it into the API server so that proxy-supplied client metadata (`X-Forwarded-*`) is only honored from explicitly configured upstream hops. When unset, no proxy is trusted and the direct connection address is used.

## Changes
- New `server.trusted_proxies` config option (list of CIDRs / IPs), default empty.
- Gin's trusted proxy list is now driven by this option.
- Scheme detection only honors forwarded headers from a trusted peer.
- Updated sample config files and the configuration docs table.
- Added unit tests covering parsing and trusted vs. untrusted sources.

## Notes
Deployments behind a TLS-terminating reverse proxy should set `server.trusted_proxies` to the proxy's address range; otherwise forwarded headers are ignored (secure by default).

## Validation
- `go build ./...`
- `go test ./...` (config + middleware packages green)
- `golangci-lint run`