### PR TITLE
Add baseline security response headers

### DIFF
--- a/apiserver/internal/utils/middleware/middleware.go
+++ b/apiserver/internal/utils/middleware/middleware.go
@@ -65,6 +65,18 @@ func effectiveScheme(c *gin.Context) string {
 	return "http"
 }
 
+const contentSecurityPolicy = "default-src 'self'; " +
+	"base-uri 'self'; " +
+	"object-src 'none'; " +
+	"frame-ancestors 'none'; " +
+	"img-src 'self' data:; " +
+	"font-src 'self' data:; " +
+	"style-src 'self' 'unsafe-inline'; " +
+	"script-src 'self'; " +
+	"connect-src 'self' https://login.microsoftonline.com; " +
+	"frame-src 'self' https://login.microsoftonline.com; " +
+	"form-action 'self' https://login.microsoftonline.com"
+
 func SecurityHeaders(cfg *config.Config) gin.HandlerFunc {
 	hostName := cfg.Server.HostName
 	port := cfg.Server.Port
@@ -81,6 +93,11 @@ func SecurityHeaders(cfg *config.Config) gin.HandlerFunc {
 			c.Abort()
 			return
 		}
+
+		c.Header("Content-Security-Policy", contentSecurityPolicy)
+		c.Header("X-Content-Type-Options", "nosniff")
+		c.Header("X-Frame-Options", "DENY")
+		c.Header("Referrer-Policy", "strict-origin-when-cross-origin")
 
 		if scheme == "https" {
 			c.Header("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload")

--- a/apiserver/internal/utils/middleware/middleware.go
+++ b/apiserver/internal/utils/middleware/middleware.go
@@ -83,6 +83,12 @@ func SecurityHeaders(cfg *config.Config) gin.HandlerFunc {
 
 	return func(c *gin.Context) {
 		scheme := EffectiveScheme(c)
+
+		c.Header("Content-Security-Policy", contentSecurityPolicy)
+		c.Header("X-Content-Type-Options", "nosniff")
+		c.Header("X-Frame-Options", "DENY")
+		c.Header("Referrer-Policy", "strict-origin-when-cross-origin")
+
 		if scheme == "http" && hostName != "" {
 			target := fmt.Sprintf("https://%s", hostName)
 			if port != 443 {
@@ -93,11 +99,6 @@ func SecurityHeaders(cfg *config.Config) gin.HandlerFunc {
 			c.Abort()
 			return
 		}
-
-		c.Header("Content-Security-Policy", contentSecurityPolicy)
-		c.Header("X-Content-Type-Options", "nosniff")
-		c.Header("X-Frame-Options", "DENY")
-		c.Header("Referrer-Policy", "strict-origin-when-cross-origin")
 
 		if scheme == "https" {
 			c.Header("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload")

--- a/apiserver/internal/utils/middleware/middleware_test.go
+++ b/apiserver/internal/utils/middleware/middleware_test.go
@@ -217,3 +217,50 @@ func (s *MiddlewareTestSuite) TestSecurityHeadersNoRedirectForHTTPS() {
 	s.Equal(http.StatusOK, w.Code)
 	s.Equal("max-age=31536000; includeSubDomains; preload", w.Header().Get("Strict-Transport-Security"))
 }
+
+func (s *MiddlewareTestSuite) TestSecurityHeadersAddsBaselineHeaders() {
+	cfg := &config.Config{
+		Server: config.ServerConfig{
+			HostName: "example.com",
+			Port:     443,
+		},
+	}
+
+	s.router.Use(SecurityHeaders(cfg))
+	s.router.GET("/", func(c *gin.Context) {
+		c.String(http.StatusOK, "OK")
+	})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/", nil)
+	req.Header.Set("X-Forwarded-Proto", "https")
+	s.router.ServeHTTP(w, req)
+
+	s.Equal(http.StatusOK, w.Code)
+	s.Equal("nosniff", w.Header().Get("X-Content-Type-Options"))
+	s.Equal("DENY", w.Header().Get("X-Frame-Options"))
+	s.Equal("strict-origin-when-cross-origin", w.Header().Get("Referrer-Policy"))
+	s.Equal(contentSecurityPolicy, w.Header().Get("Content-Security-Policy"))
+}
+
+func (s *MiddlewareTestSuite) TestSecurityHeadersBaselineHeadersOverPlainHTTP() {
+	cfg := &config.Config{
+		Server: config.ServerConfig{},
+	}
+
+	s.router.Use(SecurityHeaders(cfg))
+	s.router.GET("/", func(c *gin.Context) {
+		c.String(http.StatusOK, "OK")
+	})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/", nil)
+	s.router.ServeHTTP(w, req)
+
+	s.Equal(http.StatusOK, w.Code)
+	s.Equal("nosniff", w.Header().Get("X-Content-Type-Options"))
+	s.Equal("DENY", w.Header().Get("X-Frame-Options"))
+	s.Equal("strict-origin-when-cross-origin", w.Header().Get("Referrer-Policy"))
+	s.Equal(contentSecurityPolicy, w.Header().Get("Content-Security-Policy"))
+	s.Empty(w.Header().Get("Strict-Transport-Security"))
+}

--- a/apiserver/internal/utils/middleware/middleware_test.go
+++ b/apiserver/internal/utils/middleware/middleware_test.go
@@ -174,6 +174,10 @@ func (s *MiddlewareTestSuite) TestSecurityHeadersRedirectsHTTP() {
 	s.router.ServeHTTP(w, req)
 	s.Equal(http.StatusMovedPermanently, w.Code)
 	s.Equal("https://example.com/path?q=1", w.Header().Get("Location"))
+	s.Equal("nosniff", w.Header().Get("X-Content-Type-Options"))
+	s.Equal("DENY", w.Header().Get("X-Frame-Options"))
+	s.Equal("strict-origin-when-cross-origin", w.Header().Get("Referrer-Policy"))
+	s.Equal(contentSecurityPolicy, w.Header().Get("Content-Security-Policy"))
 }
 
 func (s *MiddlewareTestSuite) TestSecurityHeadersRedirectsHTTPNonStandardPort() {

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -6,6 +6,12 @@ import { defineConfig } from 'vite'
 export default defineConfig({
   plugins: [react(), version()],
 
+  build: {
+    modulePreload: {
+      polyfill: false,
+    },
+  },
+
   resolve: {
     alias: [
       {


### PR DESCRIPTION
## Summary

Strengthens the HTTP response headers emitted by the API server (which also serves the SPA) by adding a set of baseline security headers alongside the existing HSTS handling.

## Changes

- The `SecurityHeaders` middleware now sets the following on responses:
  - `Content-Security-Policy` — a policy tuned for the Vite single-page app (allows the styling runtime and the optional Microsoft sign-in flow, disallows framing and inline scripts).
  - `X-Content-Type-Options: nosniff`
  - `X-Frame-Options: DENY`
  - `Referrer-Policy: strict-origin-when-cross-origin`
- Disabled Vite's inline `modulePreload` polyfill so the production bundle contains no inline scripts, keeping the CSP `script-src` strict.
- Added middleware tests covering the new headers.

## Verification

- `go build ./...` and the middleware test suite pass; `golangci-lint run` is clean.
- `yarn lint` and `yarn build` pass; the built `index.html` contains only an external module script (no inline scripts), confirming the CSP does not break the frontend.